### PR TITLE
fix: fix app url env

### DIFF
--- a/api/registry.yml
+++ b/api/registry.yml
@@ -51,8 +51,8 @@ images:
         timeout: 30s
         retries: 3
         retry_delay: 5s
-      - command: [ "bash", "-c", "cd /var/www/html && grep -q '^APP_ENV=' \".env\" && sed -i \"s/^APP_ENV=.*/APP_ENV={{.Meta.app_env}}/\" \".env\" || echo \"APP_ENV={{.Meta.app_env}}\" >> \".env\"" ]
-        delay: 10s
+      - command: [ "bash", "-c", "printf 'APP_ENV={{.Meta.app_env}}\\nAPP_URL={{.URL}}\\n' > /var/www/html/.env.local" ]
+        delay: 20s
         timeout: 30s
         retries: 2
         retry_delay: 3s


### PR DESCRIPTION
**Beschreibung des Problems**
Wir setzen die Env-Variable APP_URL korrekt in Docker.
Dockware überschreibt das leider mit der SHOP_DOMAIN aber mit nur mit hardcoded http, anstelle von https, weshalb es zu diesem Fehler kommt, dass APP_URL nicht korrekt definiert wurde.
https://github.com/dockware/shopware/blob/8596133359d4a0fcd759bb0e4f48e74c8dbf8ae6/src/assets/scripts/shopware6/update_domain.sh#L7

**Lösung**
Wir erstellen ein Post-Start Befehl für Dockware Images in der Registry welche die korrekte APP_URL in .env.local schreibt.

Zudem setzen wir dort jetzt auch APP_ENV in .env.local statt in .env.
Das hat den Vorteil dass wir die .env.local als leeres File bekommen und dort alle Werte aus .env überschreiben können ohne in Konflikt mit Dockware in .env zu kommen.

Fixes #59 