### PR TITLE
Refactor/registry yml

### DIFF
--- a/api/internal/http/dto/image.go
+++ b/api/internal/http/dto/image.go
@@ -8,12 +8,12 @@ import (
 )
 
 type ImagePayload struct {
-	Name        string            `json:"name" validate:"required" example:"dockware/dev"`
-	Tag         string            `json:"tag" validate:"required" example:"6.6.9.0"`
-	Title       *string           `json:"title" example:"Shopware 6.6 Demo"`
-	Description *string           `json:"description" example:"Base image for internal sales demos."`
-	IsPublic    bool              `json:"isPublic" example:"true"`
-	Metadata    map[string]string `json:"metadata,omitempty"`
+	Name        string                  `json:"name" validate:"required" example:"dockware/dev"`
+	Tag         string                  `json:"tag" validate:"required" example:"6.6.9.0"`
+	Title       *string                 `json:"title" example:"Shopware 6.6 Demo"`
+	Description *string                 `json:"description" example:"Base image for internal sales demos."`
+	IsPublic    bool                    `json:"isPublic" example:"true"`
+	Metadata    []registry.MetadataItem `json:"metadata,omitempty"`
 }
 
 type CreateImageRequest struct {
@@ -21,10 +21,10 @@ type CreateImageRequest struct {
 }
 
 type UpdateImageRequest struct {
-	Title       *string           `json:"title"`
-	Description *string           `json:"description"`
-	IsPublic    bool              `json:"isPublic"`
-	Metadata    map[string]string `json:"metadata,omitempty"`
+	Title       *string                 `json:"title"`
+	Description *string                 `json:"description"`
+	IsPublic    bool                    `json:"isPublic"`
+	Metadata    []registry.MetadataItem `json:"metadata,omitempty"`
 }
 
 type ImageListResponse struct {
@@ -33,20 +33,20 @@ type ImageListResponse struct {
 }
 
 type ImageResponse struct {
-	ID           uuid.UUID                `json:"id" format:"uuid" example:"8ae13ed9-cfb1-4941-a248-bc74b9fb6a24"`
-	Name         string                   `json:"name" example:"dockware/dev"`
-	Tag          string                   `json:"tag" example:"6.6.9.0"`
-	Title        *string                  `json:"title,omitempty" example:"Shopware Demo Image"`
-	Description  *string                  `json:"description,omitempty" example:"Prepared image for sales demos and internal QA."`
-	ThumbnailURL *string                  `json:"thumbnailUrl,omitempty" example:"https://cdn.example.com/images/shopware-demo.png"`
-	IsPublic     bool                     `json:"isPublic" example:"true"`
-	Status       string                   `json:"status" example:"ready"`
-	Error        *string                  `json:"error,omitempty" example:"pull access denied"`
-	Metadata     *registry.MetadataSchema `json:"metadata,omitempty"`
-	RegistryRef  *string                  `json:"registryRef,omitempty" example:"dockware/dev"`
-	Owner        *UserSummary             `json:"owner,omitempty"`
-	CreatedAt    time.Time                `json:"createdAt" example:"2026-03-20T10:15:00Z"`
-	UpdatedAt    time.Time                `json:"updatedAt" example:"2026-03-20T10:20:00Z"`
+	ID           uuid.UUID               `json:"id" format:"uuid" example:"8ae13ed9-cfb1-4941-a248-bc74b9fb6a24"`
+	Name         string                  `json:"name" example:"dockware/dev"`
+	Tag          string                  `json:"tag" example:"6.6.9.0"`
+	Title        *string                 `json:"title,omitempty" example:"Shopware Demo Image"`
+	Description  *string                 `json:"description,omitempty" example:"Prepared image for sales demos and internal QA."`
+	ThumbnailURL *string                 `json:"thumbnailUrl,omitempty" example:"https://cdn.example.com/images/shopware-demo.png"`
+	IsPublic     bool                    `json:"isPublic" example:"true"`
+	Status       string                  `json:"status" example:"ready"`
+	Error        *string                 `json:"error,omitempty" example:"pull access denied"`
+	Metadata     []registry.MetadataItem `json:"metadata"`
+	RegistryRef  *string                 `json:"registryRef,omitempty" example:"dockware/dev"`
+	Owner        *UserSummary            `json:"owner,omitempty"`
+	CreatedAt    time.Time               `json:"createdAt" example:"2026-03-20T10:15:00Z"`
+	UpdatedAt    time.Time               `json:"updatedAt" example:"2026-03-20T10:20:00Z"`
 }
 
 type PendingImageResponse struct {

--- a/api/internal/http/dto/image.go
+++ b/api/internal/http/dto/image.go
@@ -5,16 +5,15 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/mr-pixel-kg/shopshredder/api/internal/registry"
-	"gorm.io/datatypes"
 )
 
 type ImagePayload struct {
-	Name        string                  `json:"name" validate:"required" example:"dockware/dev"`
-	Tag         string                  `json:"tag" validate:"required" example:"6.6.9.0"`
-	Title       *string                 `json:"title" example:"Shopware 6.6 Demo"`
-	Description *string                 `json:"description" example:"Base image for internal sales demos."`
-	IsPublic    bool                    `json:"isPublic" example:"true"`
-	Metadata    []registry.MetadataItem `json:"metadata,omitempty"`
+	Name        string            `json:"name" validate:"required" example:"dockware/dev"`
+	Tag         string            `json:"tag" validate:"required" example:"6.6.9.0"`
+	Title       *string           `json:"title" example:"Shopware 6.6 Demo"`
+	Description *string           `json:"description" example:"Base image for internal sales demos."`
+	IsPublic    bool              `json:"isPublic" example:"true"`
+	Metadata    map[string]string `json:"metadata,omitempty"`
 }
 
 type CreateImageRequest struct {
@@ -22,10 +21,10 @@ type CreateImageRequest struct {
 }
 
 type UpdateImageRequest struct {
-	Title       *string                 `json:"title"`
-	Description *string                 `json:"description"`
-	IsPublic    bool                    `json:"isPublic"`
-	Metadata    []registry.MetadataItem `json:"metadata,omitempty"`
+	Title       *string           `json:"title"`
+	Description *string           `json:"description"`
+	IsPublic    bool              `json:"isPublic"`
+	Metadata    map[string]string `json:"metadata,omitempty"`
 }
 
 type ImageListResponse struct {
@@ -34,20 +33,20 @@ type ImageListResponse struct {
 }
 
 type ImageResponse struct {
-	ID           uuid.UUID      `json:"id" format:"uuid" example:"8ae13ed9-cfb1-4941-a248-bc74b9fb6a24"`
-	Name         string         `json:"name" example:"dockware/dev"`
-	Tag          string         `json:"tag" example:"6.6.9.0"`
-	Title        *string        `json:"title,omitempty" example:"Shopware Demo Image"`
-	Description  *string        `json:"description,omitempty" example:"Prepared image for sales demos and internal QA."`
-	ThumbnailURL *string        `json:"thumbnailUrl,omitempty" example:"https://cdn.example.com/images/shopware-demo.png"`
-	IsPublic     bool           `json:"isPublic" example:"true"`
-	Status       string         `json:"status" example:"ready"`
-	Error        *string        `json:"error,omitempty" example:"pull access denied"`
-	Metadata     datatypes.JSON `json:"metadata,omitempty" swaggertype:"string"`
-	RegistryRef  *string        `json:"registryRef,omitempty" example:"dockware/dev"`
-	Owner        *UserSummary   `json:"owner,omitempty"`
-	CreatedAt    time.Time      `json:"createdAt" example:"2026-03-20T10:15:00Z"`
-	UpdatedAt    time.Time      `json:"updatedAt" example:"2026-03-20T10:20:00Z"`
+	ID           uuid.UUID                `json:"id" format:"uuid" example:"8ae13ed9-cfb1-4941-a248-bc74b9fb6a24"`
+	Name         string                   `json:"name" example:"dockware/dev"`
+	Tag          string                   `json:"tag" example:"6.6.9.0"`
+	Title        *string                  `json:"title,omitempty" example:"Shopware Demo Image"`
+	Description  *string                  `json:"description,omitempty" example:"Prepared image for sales demos and internal QA."`
+	ThumbnailURL *string                  `json:"thumbnailUrl,omitempty" example:"https://cdn.example.com/images/shopware-demo.png"`
+	IsPublic     bool                     `json:"isPublic" example:"true"`
+	Status       string                   `json:"status" example:"ready"`
+	Error        *string                  `json:"error,omitempty" example:"pull access denied"`
+	Metadata     *registry.MetadataSchema `json:"metadata,omitempty"`
+	RegistryRef  *string                  `json:"registryRef,omitempty" example:"dockware/dev"`
+	Owner        *UserSummary             `json:"owner,omitempty"`
+	CreatedAt    time.Time                `json:"createdAt" example:"2026-03-20T10:15:00Z"`
+	UpdatedAt    time.Time                `json:"updatedAt" example:"2026-03-20T10:20:00Z"`
 }
 
 type PendingImageResponse struct {

--- a/api/internal/http/dto/sandbox.go
+++ b/api/internal/http/dto/sandbox.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/mr-pixel-kg/shopshredder/api/internal/models"
-	"gorm.io/datatypes"
+	"github.com/mr-pixel-kg/shopshredder/api/internal/registry"
 )
 
 type CreateSandboxRequest struct {
@@ -30,24 +30,24 @@ type SandboxListResponse struct {
 }
 
 type SandboxResponse struct {
-	ID            uuid.UUID            `json:"id" format:"uuid" example:"0b443c82-d8a3-49a7-b59a-26ce327c7341"`
-	ImageID       uuid.UUID            `json:"imageId" format:"uuid" example:"8ae13ed9-cfb1-4941-a248-bc74b9fb6a24"`
-	Owner         *UserSummary         `json:"owner,omitempty"`
-	ClientID      *uuid.UUID           `json:"clientId,omitempty" format:"uuid" example:"db7fcb92-c2ff-4c20-9ac2-5a2504ab6326"`
-	DisplayName   string               `json:"displayName" example:"My Test Shop"`
-	Status        models.SandboxStatus `json:"status" enums:"starting,running,paused,stopping,stopped,expired,deleted,failed" example:"running"`
-	StateReason   *string              `json:"stateReason,omitempty" example:"Snapshot wird erstellt"`
-	ContainerID   string               `json:"containerId" example:"1a2b3c4d5e6f7g8h9i0j"`
-	ContainerName string               `json:"containerName" example:"sandbox-0b443c82"`
-	URL           string               `json:"url" example:"https://sandbox-0b443c82.demo.shopshredder.de"`
-	Port          *int                 `json:"port,omitempty" example:"8080"`
-	SSH           *SSHConnectionInfo   `json:"ssh,omitempty"`
-	ClientIP      string               `json:"clientIp" example:"203.0.113.25"`
-	Metadata      datatypes.JSON       `json:"metadata,omitempty" swaggertype:"string"`
-	ExpiresAt     *time.Time           `json:"expiresAt,omitempty" example:"2026-03-20T12:00:00Z"`
-	LastSeenAt    *time.Time           `json:"lastSeenAt,omitempty" example:"2026-03-20T10:45:00Z"`
-	CreatedAt     time.Time            `json:"createdAt" example:"2026-03-20T10:15:00Z"`
-	UpdatedAt     time.Time            `json:"updatedAt" example:"2026-03-20T10:20:00Z"`
+	ID            uuid.UUID                `json:"id" format:"uuid" example:"0b443c82-d8a3-49a7-b59a-26ce327c7341"`
+	ImageID       uuid.UUID                `json:"imageId" format:"uuid" example:"8ae13ed9-cfb1-4941-a248-bc74b9fb6a24"`
+	Owner         *UserSummary             `json:"owner,omitempty"`
+	ClientID      *uuid.UUID               `json:"clientId,omitempty" format:"uuid" example:"db7fcb92-c2ff-4c20-9ac2-5a2504ab6326"`
+	DisplayName   string                   `json:"displayName" example:"My Test Shop"`
+	Status        models.SandboxStatus     `json:"status" enums:"starting,running,paused,stopping,stopped,expired,deleted,failed" example:"running"`
+	StateReason   *string                  `json:"stateReason,omitempty" example:"Snapshot wird erstellt"`
+	ContainerID   string                   `json:"containerId" example:"1a2b3c4d5e6f7g8h9i0j"`
+	ContainerName string                   `json:"containerName" example:"sandbox-0b443c82"`
+	URL           string                   `json:"url" example:"https://sandbox-0b443c82.demo.shopshredder.de"`
+	Port          *int                     `json:"port,omitempty" example:"8080"`
+	SSH           *SSHConnectionInfo       `json:"ssh,omitempty"`
+	ClientIP      string                   `json:"clientIp" example:"203.0.113.25"`
+	Metadata      *registry.MetadataSchema `json:"metadata,omitempty"`
+	ExpiresAt     *time.Time               `json:"expiresAt,omitempty" example:"2026-03-20T12:00:00Z"`
+	LastSeenAt    *time.Time               `json:"lastSeenAt,omitempty" example:"2026-03-20T10:45:00Z"`
+	CreatedAt     time.Time                `json:"createdAt" example:"2026-03-20T10:15:00Z"`
+	UpdatedAt     time.Time                `json:"updatedAt" example:"2026-03-20T10:20:00Z"`
 }
 
 type SSHConnectionInfo struct {

--- a/api/internal/http/dto/sandbox.go
+++ b/api/internal/http/dto/sandbox.go
@@ -30,24 +30,24 @@ type SandboxListResponse struct {
 }
 
 type SandboxResponse struct {
-	ID            uuid.UUID                `json:"id" format:"uuid" example:"0b443c82-d8a3-49a7-b59a-26ce327c7341"`
-	ImageID       uuid.UUID                `json:"imageId" format:"uuid" example:"8ae13ed9-cfb1-4941-a248-bc74b9fb6a24"`
-	Owner         *UserSummary             `json:"owner,omitempty"`
-	ClientID      *uuid.UUID               `json:"clientId,omitempty" format:"uuid" example:"db7fcb92-c2ff-4c20-9ac2-5a2504ab6326"`
-	DisplayName   string                   `json:"displayName" example:"My Test Shop"`
-	Status        models.SandboxStatus     `json:"status" enums:"starting,running,paused,stopping,stopped,expired,deleted,failed" example:"running"`
-	StateReason   *string                  `json:"stateReason,omitempty" example:"Snapshot wird erstellt"`
-	ContainerID   string                   `json:"containerId" example:"1a2b3c4d5e6f7g8h9i0j"`
-	ContainerName string                   `json:"containerName" example:"sandbox-0b443c82"`
-	URL           string                   `json:"url" example:"https://sandbox-0b443c82.demo.shopshredder.de"`
-	Port          *int                     `json:"port,omitempty" example:"8080"`
-	SSH           *SSHConnectionInfo       `json:"ssh,omitempty"`
-	ClientIP      string                   `json:"clientIp" example:"203.0.113.25"`
-	Metadata      *registry.MetadataSchema `json:"metadata,omitempty"`
-	ExpiresAt     *time.Time               `json:"expiresAt,omitempty" example:"2026-03-20T12:00:00Z"`
-	LastSeenAt    *time.Time               `json:"lastSeenAt,omitempty" example:"2026-03-20T10:45:00Z"`
-	CreatedAt     time.Time                `json:"createdAt" example:"2026-03-20T10:15:00Z"`
-	UpdatedAt     time.Time                `json:"updatedAt" example:"2026-03-20T10:20:00Z"`
+	ID            uuid.UUID               `json:"id" format:"uuid" example:"0b443c82-d8a3-49a7-b59a-26ce327c7341"`
+	ImageID       uuid.UUID               `json:"imageId" format:"uuid" example:"8ae13ed9-cfb1-4941-a248-bc74b9fb6a24"`
+	Owner         *UserSummary            `json:"owner,omitempty"`
+	ClientID      *uuid.UUID              `json:"clientId,omitempty" format:"uuid" example:"db7fcb92-c2ff-4c20-9ac2-5a2504ab6326"`
+	DisplayName   string                  `json:"displayName" example:"My Test Shop"`
+	Status        models.SandboxStatus    `json:"status" enums:"starting,running,paused,stopping,stopped,expired,deleted,failed" example:"running"`
+	StateReason   *string                 `json:"stateReason,omitempty" example:"Snapshot wird erstellt"`
+	ContainerID   string                  `json:"containerId" example:"1a2b3c4d5e6f7g8h9i0j"`
+	ContainerName string                  `json:"containerName" example:"sandbox-0b443c82"`
+	URL           string                  `json:"url" example:"https://sandbox-0b443c82.demo.shopshredder.de"`
+	Port          *int                    `json:"port,omitempty" example:"8080"`
+	SSH           *SSHConnectionInfo      `json:"ssh,omitempty"`
+	ClientIP      string                  `json:"clientIp" example:"203.0.113.25"`
+	Metadata      []registry.MetadataItem `json:"metadata"`
+	ExpiresAt     *time.Time              `json:"expiresAt,omitempty" example:"2026-03-20T12:00:00Z"`
+	LastSeenAt    *time.Time              `json:"lastSeenAt,omitempty" example:"2026-03-20T10:45:00Z"`
+	CreatedAt     time.Time               `json:"createdAt" example:"2026-03-20T10:15:00Z"`
+	UpdatedAt     time.Time               `json:"updatedAt" example:"2026-03-20T10:20:00Z"`
 }
 
 type SSHConnectionInfo struct {

--- a/api/internal/http/handlers/image_handler.go
+++ b/api/internal/http/handlers/image_handler.go
@@ -51,9 +51,11 @@ func (h ImageHandler) ListImages(c fuego.ContextNoBody) (dto.ImageListResponse, 
 		return dto.ImageListResponse{}, fuego.HTTPError{Status: http.StatusInternalServerError, Detail: "Could not load images"}
 	}
 
+	meta := h.Images.EnrichMetadata(result.Images)
 	out := make([]dto.ImageResponse, len(result.Images))
 	for i := range result.Images {
-		out[i] = imageToResponse(&result.Images[i])
+		img := &result.Images[i]
+		out[i] = imageToResponse(img, meta[img.ID])
 	}
 	return dto.ImageListResponse{
 		Data: out,
@@ -72,14 +74,13 @@ func (h ImageHandler) Create(c fuego.ContextWithBody[dto.CreateImageRequest]) (d
 	auth := mw.MustAuth(c.Request())
 	slog.Debug("image creation requested", "component", "image", "user_id", auth.UserID, "name", body.Name, "tag", body.Tag)
 
-	metadataJSON, _ := json.Marshal(body.Metadata)
 	image, err := h.Images.CreateForUser(
 		c.Request().Context(),
 		&auth.UserID,
 		body.Name, body.Tag,
 		body.Title, body.Description,
 		body.IsPublic,
-		metadataJSON, nil,
+		body.Metadata, nil,
 	)
 	if err != nil {
 		return dto.ImageResponse{}, mapImageError(err)
@@ -91,7 +92,7 @@ func (h ImageHandler) Create(c fuego.ContextWithBody[dto.CreateImageRequest]) (d
 	}))
 
 	slog.Info("image created", "component", "image", "user_id", auth.UserID, "image_id", image.ID, "image", image.FullName(), "status", image.Status)
-	return imageToResponse(image), nil
+	return imageResponseFor(h.Images, image), nil
 }
 
 func (h ImageHandler) Update(c fuego.ContextWithBody[dto.UpdateImageRequest]) (dto.ImageResponse, error) {
@@ -106,8 +107,7 @@ func (h ImageHandler) Update(c fuego.ContextWithBody[dto.UpdateImageRequest]) (d
 		return dto.ImageResponse{}, fuego.HTTPError{Status: http.StatusBadRequest, Detail: "Invalid request body"}
 	}
 
-	metadataJSON, _ := json.Marshal(body.Metadata)
-	image, err := h.Images.Update(id, body.Title, body.Description, body.IsPublic, metadataJSON)
+	image, err := h.Images.Update(id, body.Title, body.Description, body.IsPublic, body.Metadata)
 	if err != nil {
 		return dto.ImageResponse{}, mapImageError(err)
 	}
@@ -115,7 +115,7 @@ func (h ImageHandler) Update(c fuego.ContextWithBody[dto.UpdateImageRequest]) (d
 	slog.Info("image updated", "component", "image", "user_id", auth.UserID, "image_id", image.ID)
 	resourceType := auditcontracts.ResourceTypeImage
 	_ = h.Audit.Log(newAuditLogInput(c.Request(), &auth.UserID, auditcontracts.ActionImageUpdated, &resourceType, &image.ID, map[string]any{}))
-	return imageToResponse(image), nil
+	return imageResponseFor(h.Images, image), nil
 }
 
 func (h ImageHandler) Delete(c fuego.ContextNoBody) (any, error) {
@@ -167,7 +167,7 @@ func (h ImageHandler) UploadThumbnail(w http.ResponseWriter, r *http.Request) {
 	_ = h.Audit.Log(newAuditLogInput(r, &auth.UserID, auditcontracts.ActionImageThumbnailUploaded, &resourceType, &image.ID, map[string]any{}))
 
 	w.Header().Set("Content-Type", "application/json")
-	_ = json.NewEncoder(w).Encode(imageToResponse(image))
+	_ = json.NewEncoder(w).Encode(imageResponseFor(h.Images, image))
 }
 
 func (h ImageHandler) DeleteThumbnail(w http.ResponseWriter, r *http.Request) {
@@ -265,7 +265,7 @@ func (h ImageHandler) Progress(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func (h ImageHandler) RegistryLookup(c fuego.ContextNoBody) ([]registry.MetadataItem, error) {
+func (h ImageHandler) RegistryLookup(c fuego.ContextNoBody) (registry.MetadataSchema, error) {
 	r := c.Request()
 	name := r.URL.Query().Get("name")
 
@@ -273,30 +273,37 @@ func (h ImageHandler) RegistryLookup(c fuego.ContextNoBody) ([]registry.Metadata
 		if idStr := r.URL.Query().Get("id"); idStr != "" {
 			id, err := uuid.Parse(idStr)
 			if err != nil {
-				return nil, fuego.HTTPError{Status: http.StatusBadRequest, Detail: "Invalid image id"}
+				return registry.MetadataSchema{}, fuego.HTTPError{Status: http.StatusBadRequest, Detail: "Invalid image id"}
 			}
 			image, err := h.Images.FindByID(id)
 			if err != nil {
-				return nil, fuego.HTTPError{Status: http.StatusNotFound, Detail: "Image not found"}
+				return registry.MetadataSchema{}, fuego.HTTPError{Status: http.StatusNotFound, Detail: "Image not found"}
 			}
 			name = image.RegistryName()
 		}
 	}
 
 	if name == "" {
-		return nil, fuego.HTTPError{Status: http.StatusBadRequest, Detail: "name or id query parameter is required"}
+		return registry.MetadataSchema{}, fuego.HTTPError{Status: http.StatusBadRequest, Detail: "name or id query parameter is required"}
 	}
 
 	entry := h.Resolver.ResolveEntry(name)
 	if entry == nil {
-		return []registry.MetadataItem{}, nil
+		return registry.MetadataSchema{Items: []registry.MetadataItem{}}, nil
 	}
-	meta := make([]registry.MetadataItem, len(entry.Metadata))
-	copy(meta, entry.Metadata)
-	return meta, nil
+	out := registry.MetadataSchema{
+		Groups: append([]registry.MetadataGroup(nil), entry.Metadata.Groups...),
+		Items:  append([]registry.MetadataItem(nil), entry.Metadata.Items...),
+	}
+	return out, nil
 }
 
-func imageToResponse(img *models.Image) dto.ImageResponse {
+func imageResponseFor(s *services.ImageService, img *models.Image) dto.ImageResponse {
+	meta := s.EnrichMetadata([]models.Image{*img})
+	return imageToResponse(img, meta[img.ID])
+}
+
+func imageToResponse(img *models.Image, metadata *registry.MetadataSchema) dto.ImageResponse {
 	var owner *dto.UserSummary
 	if img.Owner != nil {
 		owner = &dto.UserSummary{ID: img.Owner.ID, Email: img.Owner.Email, AvatarURL: dto.GravatarURL(img.Owner.Email, 80)}
@@ -306,7 +313,7 @@ func imageToResponse(img *models.Image) dto.ImageResponse {
 		Title: img.Title, Description: img.Description,
 		ThumbnailURL: img.ThumbnailURL, IsPublic: img.IsPublic,
 		Status: img.Status, Error: img.Error,
-		Metadata: img.Metadata, RegistryRef: img.RegistryRef,
+		Metadata: metadata, RegistryRef: img.RegistryRef,
 		Owner:     owner,
 		CreatedAt: img.CreatedAt, UpdatedAt: img.UpdatedAt,
 	}

--- a/api/internal/http/handlers/image_handler.go
+++ b/api/internal/http/handlers/image_handler.go
@@ -21,7 +21,7 @@ import (
 )
 
 type RegistryResolver interface {
-	ResolveEntry(imageName string) *registry.ImageEntry
+	SchemaFor(imageName string) *registry.MetadataSchema
 }
 
 type ImageHandler struct {
@@ -287,15 +287,10 @@ func (h ImageHandler) RegistryLookup(c fuego.ContextNoBody) (registry.MetadataSc
 		return registry.MetadataSchema{}, fuego.HTTPError{Status: http.StatusBadRequest, Detail: "name or id query parameter is required"}
 	}
 
-	entry := h.Resolver.ResolveEntry(name)
-	if entry == nil {
-		return registry.MetadataSchema{Items: []registry.MetadataItem{}}, nil
+	if schema := h.Resolver.SchemaFor(name); schema != nil {
+		return *schema, nil
 	}
-	out := registry.MetadataSchema{
-		Groups: append([]registry.MetadataGroup(nil), entry.Metadata.Groups...),
-		Items:  append([]registry.MetadataItem(nil), entry.Metadata.Items...),
-	}
-	return out, nil
+	return registry.MetadataSchema{Items: []registry.MetadataItem{}}, nil
 }
 
 func imageResponseFor(s *services.ImageService, img *models.Image) dto.ImageResponse {
@@ -303,10 +298,13 @@ func imageResponseFor(s *services.ImageService, img *models.Image) dto.ImageResp
 	return imageToResponse(img, meta[img.ID])
 }
 
-func imageToResponse(img *models.Image, metadata *registry.MetadataSchema) dto.ImageResponse {
+func imageToResponse(img *models.Image, metadata []registry.MetadataItem) dto.ImageResponse {
 	var owner *dto.UserSummary
 	if img.Owner != nil {
 		owner = &dto.UserSummary{ID: img.Owner.ID, Email: img.Owner.Email, AvatarURL: dto.GravatarURL(img.Owner.Email, 80)}
+	}
+	if metadata == nil {
+		metadata = []registry.MetadataItem{}
 	}
 	return dto.ImageResponse{
 		ID: img.ID, Name: img.Name, Tag: img.Tag,

--- a/api/internal/http/handlers/sandbox_handler.go
+++ b/api/internal/http/handlers/sandbox_handler.go
@@ -2,7 +2,6 @@ package handlers
 
 import (
 	"bytes"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -24,6 +23,7 @@ import (
 
 type SandboxHandler struct {
 	Sandboxes *services.SandboxService
+	Images    *services.ImageService
 	Health    *services.SandboxHealthService
 	Auth      *services.AuthService
 }
@@ -60,9 +60,11 @@ func (h SandboxHandler) List(c fuego.ContextNoBody) (dto.SandboxListResponse, er
 	}
 
 	sshCfg := h.Sandboxes.SSHConfig()
+	enrichment := h.Sandboxes.EnrichMetadata(result.Sandboxes)
 	out := make([]dto.SandboxResponse, len(result.Sandboxes))
 	for i := range result.Sandboxes {
-		out[i] = sandboxToResponse(&result.Sandboxes[i], sshCfg, result.SSHEntries[result.Sandboxes[i].ImageID])
+		sb := &result.Sandboxes[i]
+		out[i] = sandboxToResponse(sb, sshCfg, enrichment[sb.ID])
 	}
 	return dto.SandboxListResponse{
 		Data: out,
@@ -83,8 +85,7 @@ func (h SandboxHandler) Get(c fuego.ContextNoBody) (dto.SandboxResponse, error) 
 		return dto.SandboxResponse{}, fuego.HTTPError{Status: http.StatusNotFound, Detail: "Sandbox not found"}
 	}
 
-	sshCfg := h.Sandboxes.SSHConfig()
-	return sandboxToResponse(sandbox, sshCfg, h.Sandboxes.ResolveSSHEntry(sandbox.ImageID)), nil
+	return h.sandboxResponseFor(sandbox), nil
 }
 
 func (h SandboxHandler) Create(c fuego.ContextWithBody[dto.CreateSandboxRequest]) (dto.SandboxResponse, error) {
@@ -130,8 +131,7 @@ func (h SandboxHandler) Create(c fuego.ContextWithBody[dto.CreateSandboxRequest]
 	h.Health.StartMonitoring(sandbox.ID)
 
 	slog.Info("sandbox created", "component", "sandbox", "sandbox_id", sandbox.ID, "image_id", sandbox.ImageID, "expires_at", sandbox.ExpiresAt)
-	sshCfg := h.Sandboxes.SSHConfig()
-	return sandboxToResponse(sandbox, sshCfg, h.Sandboxes.ResolveSSHEntry(sandbox.ImageID)), nil
+	return h.sandboxResponseFor(sandbox), nil
 }
 
 func (h SandboxHandler) Update(c fuego.ContextWithBody[dto.UpdateSandboxRequest]) (dto.SandboxResponse, error) {
@@ -160,8 +160,7 @@ func (h SandboxHandler) Update(c fuego.ContextWithBody[dto.UpdateSandboxRequest]
 	}
 
 	slog.Info("sandbox updated", "component", "sandbox", "user_id", auth.UserID, "sandbox_id", id)
-	sshCfg := h.Sandboxes.SSHConfig()
-	return sandboxToResponse(sandbox, sshCfg, h.Sandboxes.ResolveSSHEntry(sandbox.ImageID)), nil
+	return h.sandboxResponseFor(sandbox), nil
 }
 
 func (h SandboxHandler) Delete(c fuego.ContextNoBody) (any, error) {
@@ -224,7 +223,6 @@ func (h SandboxHandler) Snapshot(c fuego.ContextWithBody[dto.CreateSnapshotReque
 	auth := mw.MustAuth(r)
 	slog.Debug("sandbox snapshot requested", "component", "sandbox", "user_id", auth.UserID, "sandbox_id", id, "name", body.Name, "tag", body.Tag)
 
-	metadataJSON, _ := json.Marshal(body.Metadata)
 	image, err := h.Sandboxes.CreateSnapshot(r.Context(), services.CreateSnapshotInput{
 		SandboxID:   id,
 		Name:        body.Name,
@@ -234,7 +232,7 @@ func (h SandboxHandler) Snapshot(c fuego.ContextWithBody[dto.CreateSnapshotReque
 		IsPublic:    body.IsPublic,
 		ClientIP:    extractIP(r),
 		UserID:      &auth.UserID,
-		Metadata:    metadataJSON,
+		Metadata:    body.Metadata,
 		AuditActor:  newAuditActor(r, &auth.UserID),
 	})
 	if err != nil {
@@ -242,7 +240,7 @@ func (h SandboxHandler) Snapshot(c fuego.ContextWithBody[dto.CreateSnapshotReque
 	}
 
 	slog.Info("sandbox snapshot created", "component", "sandbox", "user_id", auth.UserID, "sandbox_id", id, "image_id", image.ID, "image", image.FullName())
-	return imageToResponse(image), nil
+	return imageResponseFor(h.Images, image), nil
 }
 
 func (h SandboxHandler) HealthSSE(w http.ResponseWriter, r *http.Request) {
@@ -371,14 +369,19 @@ func mapSandboxError(err error) error {
 	}
 }
 
-func sandboxToResponse(sb *models.Sandbox, sshCfg config.SSHConfig, sshEntry *registry.SSHEntry) dto.SandboxResponse {
+func (h SandboxHandler) sandboxResponseFor(sb *models.Sandbox) dto.SandboxResponse {
+	enrichment := h.Sandboxes.EnrichMetadata([]models.Sandbox{*sb})
+	return sandboxToResponse(sb, h.Sandboxes.SSHConfig(), enrichment[sb.ID])
+}
+
+func sandboxToResponse(sb *models.Sandbox, sshCfg config.SSHConfig, enrichment services.SandboxEnrichment) dto.SandboxResponse {
 	var owner *dto.UserSummary
 	if sb.Owner != nil {
 		owner = &dto.UserSummary{ID: sb.Owner.ID, Email: sb.Owner.Email, AvatarURL: dto.GravatarURL(sb.Owner.Email, 80)}
 	}
 	var ssh *dto.SSHConnectionInfo
 	if sshCfg.Enabled {
-		ssh = buildSSHInfo(sb, sshCfg, sshEntry)
+		ssh = buildSSHInfo(sb, sshCfg, enrichment.SSH)
 	}
 	return dto.SandboxResponse{
 		ID: sb.ID, ImageID: sb.ImageID, Owner: owner,
@@ -386,7 +389,7 @@ func sandboxToResponse(sb *models.Sandbox, sshCfg config.SSHConfig, sshEntry *re
 		Status: sb.Status, StateReason: sb.StateReason,
 		ContainerID: sb.ContainerID, ContainerName: sb.ContainerName,
 		URL: sb.GetURL(), Port: sb.Port, SSH: ssh, ClientIP: sb.ClientIP,
-		Metadata:  sb.Metadata,
+		Metadata:  enrichment.Metadata,
 		ExpiresAt: sb.ExpiresAt, LastSeenAt: sb.LastSeenAt,
 		CreatedAt: sb.CreatedAt, UpdatedAt: sb.UpdatedAt,
 	}

--- a/api/internal/http/routes.go
+++ b/api/internal/http/routes.go
@@ -118,7 +118,7 @@ func registerRoutes(s *fuego.Server, cfg config.Config, runtime *runtimeServices
 
 	auth := handlers.AuthHandler{Auth: runtime.auth, Audit: runtime.audit}
 	image := handlers.ImageHandler{Images: runtime.image, Audit: runtime.audit, Resolver: runtime.resolver}
-	sandbox := handlers.SandboxHandler{Sandboxes: runtime.sandbox, Health: runtime.sandboxHealth, Auth: runtime.auth}
+	sandbox := handlers.SandboxHandler{Sandboxes: runtime.sandbox, Images: runtime.image, Health: runtime.sandboxHealth, Auth: runtime.auth}
 	audit := handlers.AuditHandler{Audit: runtime.audit}
 	user := handlers.UserHandler{Users: runtime.user, Audit: runtime.audit}
 	whitelist := handlers.WhitelistHandler{Users: runtime.user, Audit: runtime.audit}

--- a/api/internal/models/image.go
+++ b/api/internal/models/image.go
@@ -13,19 +13,19 @@ const (
 )
 
 type Image struct {
-	ID           uuid.UUID      `gorm:"type:uuid;primaryKey" json:"id" format:"uuid" example:"8ae13ed9-cfb1-4941-a248-bc74b9fb6a24"`
-	Name         string         `gorm:"size:255;not null" json:"name" example:"dockware/dev"`
-	Tag          string         `gorm:"size:255;not null" json:"tag" example:"6.6.9.0"`
-	Title        *string        `gorm:"size:255" json:"title,omitempty" example:"Shopware Demo Image"`
-	Description  *string        `gorm:"type:text" json:"description,omitempty" example:"Prepared image for sales demos and internal QA."`
-	ThumbnailURL *string        `gorm:"size:1024" json:"thumbnailUrl,omitempty" example:"https://cdn.example.com/images/shopware-demo.png"`
-	IsPublic     bool           `gorm:"not null;default:false" json:"isPublic" example:"true"`
-	Status       string         `gorm:"size:32;not null;default:ready" json:"status" example:"ready"`
-	Error        *string        `gorm:"type:text" json:"error,omitempty" example:"pull access denied"`
-	Metadata     datatypes.JSON `gorm:"type:jsonb;default:'[]'" json:"metadata,omitempty" swaggertype:"string"`
-	RegistryRef  *string        `gorm:"size:255" json:"registryRef,omitempty" example:"dockware/dev"`
-	OwnerID      *uuid.UUID     `gorm:"column:owner_id;type:uuid" json:"ownerId,omitempty" format:"uuid" example:"5cc66f6f-5c71-4be4-9f2d-639dc4b8c8c2"`
-	Owner        *User          `gorm:"foreignKey:OwnerID;references:ID" json:"-" swaggerignore:"true"`
+	ID           uuid.UUID         `gorm:"type:uuid;primaryKey" json:"id" format:"uuid" example:"8ae13ed9-cfb1-4941-a248-bc74b9fb6a24"`
+	Name         string            `gorm:"size:255;not null" json:"name" example:"dockware/dev"`
+	Tag          string            `gorm:"size:255;not null" json:"tag" example:"6.6.9.0"`
+	Title        *string           `gorm:"size:255" json:"title,omitempty" example:"Shopware Demo Image"`
+	Description  *string           `gorm:"type:text" json:"description,omitempty" example:"Prepared image for sales demos and internal QA."`
+	ThumbnailURL *string           `gorm:"size:1024" json:"thumbnailUrl,omitempty" example:"https://cdn.example.com/images/shopware-demo.png"`
+	IsPublic     bool              `gorm:"not null;default:false" json:"isPublic" example:"true"`
+	Status       string            `gorm:"size:32;not null;default:ready" json:"status" example:"ready"`
+	Error        *string           `gorm:"type:text" json:"error,omitempty" example:"pull access denied"`
+	Metadata     datatypes.JSONMap `gorm:"type:jsonb;default:'{}'" json:"-" swaggerignore:"true"`
+	RegistryRef  *string           `gorm:"size:255" json:"registryRef,omitempty" example:"dockware/dev"`
+	OwnerID      *uuid.UUID        `gorm:"column:owner_id;type:uuid" json:"ownerId,omitempty" format:"uuid" example:"5cc66f6f-5c71-4be4-9f2d-639dc4b8c8c2"`
+	Owner        *User             `gorm:"foreignKey:OwnerID;references:ID" json:"-" swaggerignore:"true"`
 	BaseModel
 }
 

--- a/api/internal/models/image.go
+++ b/api/internal/models/image.go
@@ -13,19 +13,19 @@ const (
 )
 
 type Image struct {
-	ID           uuid.UUID         `gorm:"type:uuid;primaryKey" json:"id" format:"uuid" example:"8ae13ed9-cfb1-4941-a248-bc74b9fb6a24"`
-	Name         string            `gorm:"size:255;not null" json:"name" example:"dockware/dev"`
-	Tag          string            `gorm:"size:255;not null" json:"tag" example:"6.6.9.0"`
-	Title        *string           `gorm:"size:255" json:"title,omitempty" example:"Shopware Demo Image"`
-	Description  *string           `gorm:"type:text" json:"description,omitempty" example:"Prepared image for sales demos and internal QA."`
-	ThumbnailURL *string           `gorm:"size:1024" json:"thumbnailUrl,omitempty" example:"https://cdn.example.com/images/shopware-demo.png"`
-	IsPublic     bool              `gorm:"not null;default:false" json:"isPublic" example:"true"`
-	Status       string            `gorm:"size:32;not null;default:ready" json:"status" example:"ready"`
-	Error        *string           `gorm:"type:text" json:"error,omitempty" example:"pull access denied"`
-	Metadata     datatypes.JSONMap `gorm:"type:jsonb;default:'{}'" json:"-" swaggerignore:"true"`
-	RegistryRef  *string           `gorm:"size:255" json:"registryRef,omitempty" example:"dockware/dev"`
-	OwnerID      *uuid.UUID        `gorm:"column:owner_id;type:uuid" json:"ownerId,omitempty" format:"uuid" example:"5cc66f6f-5c71-4be4-9f2d-639dc4b8c8c2"`
-	Owner        *User             `gorm:"foreignKey:OwnerID;references:ID" json:"-" swaggerignore:"true"`
+	ID           uuid.UUID      `gorm:"type:uuid;primaryKey" json:"id" format:"uuid" example:"8ae13ed9-cfb1-4941-a248-bc74b9fb6a24"`
+	Name         string         `gorm:"size:255;not null" json:"name" example:"dockware/dev"`
+	Tag          string         `gorm:"size:255;not null" json:"tag" example:"6.6.9.0"`
+	Title        *string        `gorm:"size:255" json:"title,omitempty" example:"Shopware Demo Image"`
+	Description  *string        `gorm:"type:text" json:"description,omitempty" example:"Prepared image for sales demos and internal QA."`
+	ThumbnailURL *string        `gorm:"size:1024" json:"thumbnailUrl,omitempty" example:"https://cdn.example.com/images/shopware-demo.png"`
+	IsPublic     bool           `gorm:"not null;default:false" json:"isPublic" example:"true"`
+	Status       string         `gorm:"size:32;not null;default:ready" json:"status" example:"ready"`
+	Error        *string        `gorm:"type:text" json:"error,omitempty" example:"pull access denied"`
+	Metadata     datatypes.JSON `gorm:"type:jsonb;default:'[]'" json:"-" swaggerignore:"true"`
+	RegistryRef  *string        `gorm:"size:255" json:"registryRef,omitempty" example:"dockware/dev"`
+	OwnerID      *uuid.UUID     `gorm:"column:owner_id;type:uuid" json:"ownerId,omitempty" format:"uuid" example:"5cc66f6f-5c71-4be4-9f2d-639dc4b8c8c2"`
+	Owner        *User          `gorm:"foreignKey:OwnerID;references:ID" json:"-" swaggerignore:"true"`
 	BaseModel
 }
 

--- a/api/internal/models/sandbox.go
+++ b/api/internal/models/sandbox.go
@@ -37,22 +37,22 @@ func (s SandboxStatus) IsActive() bool {
 }
 
 type Sandbox struct {
-	ID            uuid.UUID      `gorm:"type:uuid;primaryKey" json:"id" format:"uuid" example:"0b443c82-d8a3-49a7-b59a-26ce327c7341"`
-	ImageID       uuid.UUID      `gorm:"type:uuid;not null;index" json:"imageId" format:"uuid" example:"8ae13ed9-cfb1-4941-a248-bc74b9fb6a24"`
-	OwnerID       *uuid.UUID     `gorm:"column:owner_id;type:uuid;index" json:"ownerId,omitempty" format:"uuid" example:"5cc66f6f-5c71-4be4-9f2d-639dc4b8c8c2"`
-	Owner         *User          `gorm:"foreignKey:OwnerID;references:ID" json:"-" swaggerignore:"true"`
-	ClientID      *uuid.UUID     `gorm:"column:client_id;type:uuid;index" json:"clientId,omitempty" format:"uuid" example:"db7fcb92-c2ff-4c20-9ac2-5a2504ab6326"`
-	DisplayName   string         `gorm:"size:255;default:''" json:"displayName" example:"My Test Shop"`
-	Status        SandboxStatus  `gorm:"size:32;not null;index" json:"status" enums:"starting,running,paused,stopping,stopped,expired,deleted,failed" example:"running"`
-	StateReason   *string        `gorm:"size:512" json:"stateReason,omitempty" example:"Snapshot wird erstellt"`
-	ContainerID   string         `gorm:"size:255;not null;uniqueIndex" json:"containerId" example:"1a2b3c4d5e6f7g8h9i0j"`
-	ContainerName string         `gorm:"size:255;not null;uniqueIndex" json:"containerName" example:"sandbox-0b443c82"`
-	URL           *string        `gorm:"size:1024;uniqueIndex" json:"url,omitempty" example:"https://sandbox-0b443c82.demo.shopshredder.de"`
-	Port          *int           `gorm:"default:null" json:"port,omitempty" example:"8080"`
-	ClientIP      string         `gorm:"size:128;not null;index" json:"clientIp" example:"203.0.113.25"`
-	Metadata      datatypes.JSON `gorm:"type:jsonb;default:'{}'" json:"metadata,omitempty" swaggertype:"string"`
-	ExpiresAt     *time.Time     `gorm:"index" json:"expiresAt,omitempty" example:"2026-03-20T12:00:00Z"`
-	LastSeenAt    *time.Time     `json:"lastSeenAt,omitempty" example:"2026-03-20T10:45:00Z"`
+	ID            uuid.UUID         `gorm:"type:uuid;primaryKey" json:"id" format:"uuid" example:"0b443c82-d8a3-49a7-b59a-26ce327c7341"`
+	ImageID       uuid.UUID         `gorm:"type:uuid;not null;index" json:"imageId" format:"uuid" example:"8ae13ed9-cfb1-4941-a248-bc74b9fb6a24"`
+	OwnerID       *uuid.UUID        `gorm:"column:owner_id;type:uuid;index" json:"ownerId,omitempty" format:"uuid" example:"5cc66f6f-5c71-4be4-9f2d-639dc4b8c8c2"`
+	Owner         *User             `gorm:"foreignKey:OwnerID;references:ID" json:"-" swaggerignore:"true"`
+	ClientID      *uuid.UUID        `gorm:"column:client_id;type:uuid;index" json:"clientId,omitempty" format:"uuid" example:"db7fcb92-c2ff-4c20-9ac2-5a2504ab6326"`
+	DisplayName   string            `gorm:"size:255;default:''" json:"displayName" example:"My Test Shop"`
+	Status        SandboxStatus     `gorm:"size:32;not null;index" json:"status" enums:"starting,running,paused,stopping,stopped,expired,deleted,failed" example:"running"`
+	StateReason   *string           `gorm:"size:512" json:"stateReason,omitempty" example:"Snapshot wird erstellt"`
+	ContainerID   string            `gorm:"size:255;not null;uniqueIndex" json:"containerId" example:"1a2b3c4d5e6f7g8h9i0j"`
+	ContainerName string            `gorm:"size:255;not null;uniqueIndex" json:"containerName" example:"sandbox-0b443c82"`
+	URL           *string           `gorm:"size:1024;uniqueIndex" json:"url,omitempty" example:"https://sandbox-0b443c82.demo.shopshredder.de"`
+	Port          *int              `gorm:"default:null" json:"port,omitempty" example:"8080"`
+	ClientIP      string            `gorm:"size:128;not null;index" json:"clientIp" example:"203.0.113.25"`
+	Metadata      datatypes.JSONMap `gorm:"type:jsonb;default:'{}'" json:"-" swaggerignore:"true"`
+	ExpiresAt     *time.Time        `gorm:"index" json:"expiresAt,omitempty" example:"2026-03-20T12:00:00Z"`
+	LastSeenAt    *time.Time        `json:"lastSeenAt,omitempty" example:"2026-03-20T10:45:00Z"`
 	BaseModel
 }
 

--- a/api/internal/registry/loader.go
+++ b/api/internal/registry/loader.go
@@ -19,72 +19,9 @@ func Load(path string) (*ImageRegistry, error) {
 		return nil, fmt.Errorf("parse registry file %s: %w", path, err)
 	}
 
-	if err := validate(&reg); err != nil {
+	if err := validateRegistry(&reg); err != nil {
 		return nil, fmt.Errorf("validate registry file %s: %w", path, err)
 	}
 
 	return &reg, nil
-}
-
-func validate(reg *ImageRegistry) error {
-	if len(reg.Images) == 0 {
-		return fmt.Errorf("registry must contain at least one image entry")
-	}
-
-	for i, entry := range reg.Images {
-		if entry.Match == "" {
-			return fmt.Errorf("entry %d: match pattern is required", i)
-		}
-
-		for j, cmd := range entry.PostStart {
-			if len(cmd.Command) == 0 {
-				return fmt.Errorf("entry %d: post_start[%d]: command must not be empty", i, j)
-			}
-		}
-
-		for j, cmd := range entry.PreStop {
-			if len(cmd.Command) == 0 {
-				return fmt.Errorf("entry %d: pre_stop[%d]: command must not be empty", i, j)
-			}
-		}
-
-		seen := make(map[string]bool)
-		for j, item := range entry.Metadata {
-			if item.Key == "" {
-				return fmt.Errorf("entry %d: metadata[%d]: key is required", i, j)
-			}
-			if item.Type == "" {
-				return fmt.Errorf("entry %d: metadata[%d]: type is required", i, j)
-			}
-			if seen[item.Key] {
-				return fmt.Errorf("entry %d: metadata[%d]: duplicate key %q", i, j, item.Key)
-			}
-			seen[item.Key] = true
-		}
-
-		seenLogKeys := make(map[string]bool)
-		for j, ls := range entry.Logs {
-			if ls.Key == "" {
-				return fmt.Errorf("entry %d: logs[%d]: key is required", i, j)
-			}
-			if ls.Label == "" {
-				return fmt.Errorf("entry %d: logs[%d]: label is required", i, j)
-			}
-			if ls.Type != LogSourceTypeDocker && ls.Type != LogSourceTypeFile && ls.Type != LogSourceTypeLifecycle {
-				return fmt.Errorf("entry %d: logs[%d]: type must be %q, %q, or %q", i, j, LogSourceTypeDocker, LogSourceTypeFile, LogSourceTypeLifecycle)
-			}
-			if ls.Type == LogSourceTypeFile && ls.Path == "" {
-				return fmt.Errorf("entry %d: logs[%d]: path is required for file log sources", i, j)
-			}
-			if (ls.Type == LogSourceTypeDocker || ls.Type == LogSourceTypeLifecycle) && ls.Path != "" {
-				return fmt.Errorf("entry %d: logs[%d]: path must not be set for %s log sources", i, j, ls.Type)
-			}
-			if seenLogKeys[ls.Key] {
-				return fmt.Errorf("entry %d: logs[%d]: duplicate key %q", i, j, ls.Key)
-			}
-			seenLogKeys[ls.Key] = true
-		}
-	}
-
-	return nil
 }

--- a/api/internal/registry/registry.go
+++ b/api/internal/registry/registry.go
@@ -2,6 +2,7 @@ package registry
 
 import (
 	"fmt"
+	"text/template"
 	"time"
 
 	"gopkg.in/yaml.v3"
@@ -39,23 +40,76 @@ type ImageEntry struct {
 	HealthCheck  *HealthCheckConfig `yaml:"health_check,omitempty"`
 	Labels       map[string]string  `yaml:"labels,omitempty"`
 	SSH          *SSHEntry          `yaml:"ssh,omitempty"`
-	Metadata     []MetadataItem     `yaml:"metadata,omitempty"`
+	Metadata     MetadataSchema     `yaml:"metadata,omitempty"`
 	Logs         []LogSource        `yaml:"logs,omitempty"`
 }
 
+type MetadataSchema struct {
+	Groups []MetadataGroup `yaml:"groups,omitempty" json:"groups,omitempty"`
+	Items  []MetadataItem  `yaml:"items,omitempty"  json:"items"`
+}
+
+type MetadataGroup struct {
+	Key         string `yaml:"key"                   json:"key"`
+	Label       string `yaml:"label"                 json:"label"`
+	Description string `yaml:"description,omitempty" json:"description,omitempty"`
+}
+
 type MetadataItem struct {
-	Key       string   `yaml:"key"                json:"key"`
-	Label     string   `yaml:"label"              json:"label"`
-	Type      string   `yaml:"type"               json:"type"`
-	Value     string   `yaml:"value,omitempty"    json:"value,omitempty"`
-	Input     string   `yaml:"input,omitempty"    json:"input,omitempty"`
-	Required  bool     `yaml:"required,omitempty" json:"required,omitempty"`
-	Options   []string `yaml:"options,omitempty"   json:"options,omitempty"`
-	Variant   string   `yaml:"variant,omitempty"   json:"variant,omitempty"`
-	Show      string   `yaml:"show,omitempty"      json:"show,omitempty"`
-	Condition string   `yaml:"condition,omitempty" json:"condition,omitempty"`
-	Icon      string   `yaml:"icon,omitempty"      json:"icon,omitempty"`
-	Size      string   `yaml:"size,omitempty"      json:"size,omitempty"`
+	Key        string          `yaml:"key"                  json:"key"`
+	Label      string          `yaml:"label"                json:"label"`
+	Type       string          `yaml:"type"                 json:"type"`
+	Icon       string          `yaml:"icon,omitempty"       json:"icon,omitempty"`
+	Group      string          `yaml:"group,omitempty"      json:"group,omitempty"`
+	Visibility *VisibilityRule `yaml:"visibility,omitempty" json:"visibility,omitempty"`
+
+	Field   *FieldSpec   `yaml:"field,omitempty"   json:"field,omitempty"`
+	Action  *ActionSpec  `yaml:"action,omitempty"  json:"action,omitempty"`
+	Display *DisplaySpec `yaml:"display,omitempty" json:"display,omitempty"`
+}
+
+type VisibilityRule struct {
+	Contexts  []string         `yaml:"contexts,omitempty"   json:"contexts,omitempty"`
+	Condition string           `yaml:"condition,omitempty"  json:"condition,omitempty"`
+	DependsOn *FieldDependency `yaml:"depends_on,omitempty" json:"dependsOn,omitempty"`
+}
+
+type FieldDependency struct {
+	Field string `yaml:"field" json:"field"`
+	Value string `yaml:"value" json:"value"`
+}
+
+type FieldSpec struct {
+	Input       string         `yaml:"input"                 json:"input"`
+	Default     string         `yaml:"default,omitempty"     json:"default,omitempty"`
+	Placeholder string         `yaml:"placeholder,omitempty" json:"placeholder,omitempty"`
+	HelpText    string         `yaml:"help_text,omitempty"   json:"helpText,omitempty"`
+	Required    bool           `yaml:"required,omitempty"    json:"required,omitempty"`
+	ReadOnly    bool           `yaml:"read_only,omitempty"   json:"readOnly,omitempty"`
+	Options     []SelectOption `yaml:"options,omitempty"     json:"options,omitempty"`
+	Value       string         `yaml:"-"                     json:"value"`
+}
+
+type SelectOption struct {
+	Value string `yaml:"value" json:"value"`
+	Label string `yaml:"label" json:"label"`
+}
+
+type ActionSpec struct {
+	URL     string             `yaml:"url"               json:"url"`
+	Variant string             `yaml:"variant,omitempty" json:"variant,omitempty"`
+	Size    string             `yaml:"size,omitempty"    json:"size,omitempty"`
+	Target  string             `yaml:"target,omitempty"  json:"target,omitempty"`
+	Confirm string             `yaml:"confirm,omitempty" json:"confirm,omitempty"`
+	urlTmpl *template.Template `yaml:"-" json:"-"`
+}
+
+type DisplaySpec struct {
+	Value    string `yaml:"value"              json:"value"`
+	Format   string `yaml:"format,omitempty"   json:"format,omitempty"`
+	Copyable bool   `yaml:"copyable,omitempty" json:"copyable,omitempty"`
+
+	valueTmpl *template.Template `yaml:"-" json:"-"`
 }
 
 type ExecCommand struct {
@@ -82,6 +136,7 @@ type TemplateContext struct {
 	SSHUsername    string
 	SSHPassword    string
 	ContainerName  string
+	ContainerID    string
 	TrustedProxies string
 	DockerMode     string
 	Network        string
@@ -94,6 +149,7 @@ type TemplateContext struct {
 	TTL            string
 	ExpiresAt      string
 	ClientIP       string
+	Status         string
 	Meta           map[string]string
 }
 
@@ -122,3 +178,24 @@ type ResolvedImage struct {
 	SSH          *SSHEntry
 	Logs         []LogSource
 }
+
+var ValidContexts = map[string]bool{
+	"image.create":    true,
+	"image.edit":      true,
+	"image.card":      true,
+	"sandbox.create":  true,
+	"sandbox.card":    true,
+	"sandbox.details": true,
+}
+
+var (
+	ValidFieldInputs = map[string]bool{
+		"text": true, "password": true, "number": true, "email": true, "url": true,
+		"select": true, "multiselect": true, "toggle": true, "textarea": true,
+	}
+	ValidActionVariants = map[string]bool{"default": true, "outline": true, "destructive": true}
+	ValidActionSizes    = map[string]bool{"default": true, "icon": true}
+	ValidActionTargets  = map[string]bool{"_blank": true, "_self": true}
+	ValidDisplayFormats = map[string]bool{"text": true, "code": true, "badge": true, "link": true, "password": true}
+	ValidItemTypes      = map[string]bool{"field": true, "action": true, "display": true}
+)

--- a/api/internal/registry/registry.go
+++ b/api/internal/registry/registry.go
@@ -57,7 +57,7 @@ type MetadataGroup struct {
 
 type MetadataItem struct {
 	Key        string          `yaml:"key"                  json:"key"`
-	Label      string          `yaml:"label"                json:"label"`
+	Label      string          `yaml:"label"                json:"label,omitempty"`
 	Type       string          `yaml:"type"                 json:"type"`
 	Icon       string          `yaml:"icon,omitempty"       json:"icon,omitempty"`
 	Group      string          `yaml:"group,omitempty"      json:"group,omitempty"`
@@ -80,14 +80,13 @@ type FieldDependency struct {
 }
 
 type FieldSpec struct {
-	Input       string         `yaml:"input"                 json:"input"`
+	Input       string         `yaml:"input"                 json:"input,omitempty"`
 	Default     string         `yaml:"default,omitempty"     json:"default,omitempty"`
 	Placeholder string         `yaml:"placeholder,omitempty" json:"placeholder,omitempty"`
 	HelpText    string         `yaml:"help_text,omitempty"   json:"helpText,omitempty"`
 	Required    bool           `yaml:"required,omitempty"    json:"required,omitempty"`
 	ReadOnly    bool           `yaml:"read_only,omitempty"   json:"readOnly,omitempty"`
 	Options     []SelectOption `yaml:"options,omitempty"     json:"options,omitempty"`
-	Value       string         `yaml:"-"                     json:"value"`
 }
 
 type SelectOption struct {
@@ -96,7 +95,7 @@ type SelectOption struct {
 }
 
 type ActionSpec struct {
-	URL     string             `yaml:"url"               json:"url"`
+	URL     string             `yaml:"url"               json:"url,omitempty"`
 	Variant string             `yaml:"variant,omitempty" json:"variant,omitempty"`
 	Size    string             `yaml:"size,omitempty"    json:"size,omitempty"`
 	Target  string             `yaml:"target,omitempty"  json:"target,omitempty"`
@@ -105,7 +104,7 @@ type ActionSpec struct {
 }
 
 type DisplaySpec struct {
-	Value    string `yaml:"value"              json:"value"`
+	Value    string `yaml:"value"              json:"value,omitempty"`
 	Format   string `yaml:"format,omitempty"   json:"format,omitempty"`
 	Copyable bool   `yaml:"copyable,omitempty" json:"copyable,omitempty"`
 

--- a/api/internal/registry/resolver.go
+++ b/api/internal/registry/resolver.go
@@ -74,9 +74,12 @@ func renderEntry(entry ImageEntry, ctx TemplateContext) (*ResolvedImage, error) 
 	if ctx.Meta == nil {
 		ctx.Meta = make(map[string]string)
 	}
-	for _, m := range entry.Metadata {
-		if _, ok := ctx.Meta[m.Key]; !ok && m.Value != "" {
-			ctx.Meta[m.Key] = m.Value
+	for _, it := range entry.Metadata.Items {
+		if it.Type != "field" || it.Field == nil || it.Field.Default == "" {
+			continue
+		}
+		if _, ok := ctx.Meta[it.Key]; !ok {
+			ctx.Meta[it.Key] = it.Field.Default
 		}
 	}
 
@@ -172,6 +175,94 @@ func renderExecCommand(cmd ExecCommand, ctx TemplateContext) (ExecCommand, error
 		rendered.Command = append(rendered.Command, r)
 	}
 	return rendered, nil
+}
+
+func (r *Resolver) RenderMetadata(imageName string, values map[string]string, ctx TemplateContext) (*MetadataSchema, error) {
+	entry := r.ResolveEntry(imageName)
+	if entry == nil {
+		return &MetadataSchema{}, nil
+	}
+	return RenderMetadata(&entry.Metadata, values, ctx)
+}
+
+func RenderMetadata(schema *MetadataSchema, values map[string]string, ctx TemplateContext) (*MetadataSchema, error) {
+	if schema == nil {
+		return &MetadataSchema{}, nil
+	}
+	out := &MetadataSchema{
+		Groups: append([]MetadataGroup(nil), schema.Groups...),
+		Items:  make([]MetadataItem, len(schema.Items)),
+	}
+
+	meta := make(map[string]string)
+	for _, it := range schema.Items {
+		if it.Type == "field" && it.Field != nil && it.Field.Default != "" {
+			meta[it.Key] = it.Field.Default
+		}
+	}
+	defined := make(map[string]bool, len(schema.Items))
+	for _, it := range schema.Items {
+		if it.Type == "field" {
+			defined[it.Key] = true
+		}
+	}
+	for k, v := range values {
+		if defined[k] {
+			meta[k] = v
+		}
+	}
+	ctx.Meta = meta
+
+	for i, it := range schema.Items {
+		clone := it
+		switch it.Type {
+		case "field":
+			if it.Field != nil {
+				f := *it.Field
+				if v, ok := values[it.Key]; ok {
+					f.Value = v
+				} else {
+					f.Value = it.Field.Default
+				}
+				clone.Field = &f
+			}
+		case "action":
+			if it.Action != nil {
+				a := *it.Action
+				if it.Action.urlTmpl != nil {
+					rendered, err := execTemplate(it.Action.urlTmpl, ctx)
+					if err != nil {
+						return nil, fmt.Errorf("render action.url for %q: %w", it.Key, err)
+					}
+					a.URL = rendered
+				}
+				clone.Action = &a
+			}
+		case "display":
+			if it.Display != nil {
+				d := *it.Display
+				if it.Display.valueTmpl != nil {
+					rendered, err := execTemplate(it.Display.valueTmpl, ctx)
+					if err != nil {
+						return nil, fmt.Errorf("render display.value for %q: %w", it.Key, err)
+					}
+					d.Value = rendered
+				}
+				clone.Display = &d
+			}
+		}
+		out.Items[i] = clone
+	}
+
+	return out, nil
+}
+
+func execTemplate(t *template.Template, ctx TemplateContext) (string, error) {
+	var buf bytes.Buffer
+	if err := t.Execute(&buf, ctx); err != nil {
+		return "", err
+	}
+	return buf.String(), nil
 }
 
 func renderTemplate(text string, ctx TemplateContext) (string, error) {

--- a/api/internal/registry/resolver.go
+++ b/api/internal/registry/resolver.go
@@ -177,84 +177,88 @@ func renderExecCommand(cmd ExecCommand, ctx TemplateContext) (ExecCommand, error
 	return rendered, nil
 }
 
-func (r *Resolver) RenderMetadata(imageName string, values map[string]string, ctx TemplateContext) (*MetadataSchema, error) {
-	entry := r.ResolveEntry(imageName)
-	if entry == nil {
-		return &MetadataSchema{}, nil
-	}
-	return RenderMetadata(&entry.Metadata, values, ctx)
+func (r *Resolver) RenderMetadata(imageName string, values map[string]string, metadata []MetadataItem, ctx TemplateContext) ([]MetadataItem, error) {
+	return RenderMetadata(r.SchemaFor(imageName), values, metadata, ctx)
 }
 
-func RenderMetadata(schema *MetadataSchema, values map[string]string, ctx TemplateContext) (*MetadataSchema, error) {
-	if schema == nil {
-		return &MetadataSchema{}, nil
+func (r *Resolver) SchemaFor(imageName string) *MetadataSchema {
+	if r == nil {
+		return nil
 	}
-	out := &MetadataSchema{
-		Groups: append([]MetadataGroup(nil), schema.Groups...),
-		Items:  make([]MetadataItem, len(schema.Items)),
+	entry := r.ResolveEntry(imageName)
+	if entry == nil {
+		return nil
 	}
+	return &entry.Metadata
+}
 
-	meta := make(map[string]string)
-	for _, it := range schema.Items {
-		if it.Type == "field" && it.Field != nil && it.Field.Default != "" {
+func (r *Resolver) MergeMetadata(imageName string, metadata []MetadataItem) []MetadataItem {
+	return MergeWithRegistry(r.SchemaFor(imageName), metadata)
+}
+
+func RenderMetadata(registrySchema *MetadataSchema, values map[string]string, metadata []MetadataItem, ctx TemplateContext) ([]MetadataItem, error) {
+	merged := MergeWithRegistry(registrySchema, metadata)
+
+	meta := make(map[string]string, len(merged))
+	for _, it := range merged {
+		if it.Type == "field" && it.Field != nil {
 			meta[it.Key] = it.Field.Default
 		}
 	}
-	defined := make(map[string]bool, len(schema.Items))
-	for _, it := range schema.Items {
-		if it.Type == "field" {
-			defined[it.Key] = true
-		}
-	}
 	for k, v := range values {
-		if defined[k] {
+		if _, ok := meta[k]; ok {
 			meta[k] = v
 		}
 	}
 	ctx.Meta = meta
 
-	for i, it := range schema.Items {
+	out := make([]MetadataItem, len(merged))
+	for i, it := range merged {
 		clone := it
 		switch it.Type {
 		case "field":
 			if it.Field != nil {
 				f := *it.Field
 				if v, ok := values[it.Key]; ok {
-					f.Value = v
-				} else {
-					f.Value = it.Field.Default
+					f.Default = v
 				}
 				clone.Field = &f
 			}
 		case "action":
 			if it.Action != nil {
 				a := *it.Action
-				if it.Action.urlTmpl != nil {
-					rendered, err := execTemplate(it.Action.urlTmpl, ctx)
-					if err != nil {
-						return nil, fmt.Errorf("render action.url for %q: %w", it.Key, err)
-					}
-					a.URL = rendered
+				rendered, err := renderInlineTemplate(it.Action.urlTmpl, a.URL, ctx)
+				if err != nil {
+					return nil, fmt.Errorf("render action.url for %q: %w", it.Key, err)
 				}
+				a.URL = rendered
 				clone.Action = &a
 			}
 		case "display":
 			if it.Display != nil {
 				d := *it.Display
-				if it.Display.valueTmpl != nil {
-					rendered, err := execTemplate(it.Display.valueTmpl, ctx)
-					if err != nil {
-						return nil, fmt.Errorf("render display.value for %q: %w", it.Key, err)
-					}
-					d.Value = rendered
+				rendered, err := renderInlineTemplate(it.Display.valueTmpl, d.Value, ctx)
+				if err != nil {
+					return nil, fmt.Errorf("render display.value for %q: %w", it.Key, err)
 				}
+				d.Value = rendered
 				clone.Display = &d
 			}
 		}
-		out.Items[i] = clone
+		out[i] = clone
 	}
 
 	return out, nil
+}
+
+func renderInlineTemplate(cached *template.Template, source string, ctx TemplateContext) (string, error) {
+	if cached != nil {
+		return execTemplate(cached, ctx)
+	}
+	if source == "" {
+		return "", nil
+	}
+	return renderTemplate(source, ctx)
 }
 
 func execTemplate(t *template.Template, ctx TemplateContext) (string, error) {
@@ -275,4 +279,76 @@ func renderTemplate(text string, ctx TemplateContext) (string, error) {
 		return "", err
 	}
 	return buf.String(), nil
+}
+
+func MergeWithRegistry(registrySchema *MetadataSchema, userItems []MetadataItem) []MetadataItem {
+	userByKey := map[string]MetadataItem{}
+	for _, it := range userItems {
+		userByKey[it.Key] = it
+	}
+	var registryItems []MetadataItem
+	if registrySchema != nil {
+		registryItems = registrySchema.Items
+	}
+	out := make([]MetadataItem, 0, len(registryItems)+len(userItems))
+	for _, it := range registryItems {
+		if patch, ok := userByKey[it.Key]; ok {
+			out = append(out, mergeItem(it, patch))
+			delete(userByKey, it.Key)
+			continue
+		}
+		out = append(out, it)
+	}
+	for _, it := range userItems {
+		if _, ok := userByKey[it.Key]; ok {
+			out = append(out, it)
+		}
+	}
+	return out
+}
+
+func StripRegistryDuplicates(userItems []MetadataItem, registrySchema *MetadataSchema) []MetadataItem {
+	registryByKey := map[string]MetadataItem{}
+	if registrySchema != nil {
+		for _, it := range registrySchema.Items {
+			registryByKey[it.Key] = it
+		}
+	}
+	out := make([]MetadataItem, 0, len(userItems))
+	for _, it := range userItems {
+		ref, hasMatch := registryByKey[it.Key]
+		if !hasMatch {
+			out = append(out, it)
+			continue
+		}
+		if patch, ok := extractOverride(it, ref); ok {
+			out = append(out, patch)
+		}
+	}
+	return out
+}
+
+func extractOverride(user, ref MetadataItem) (MetadataItem, bool) {
+	if user.Type != "field" || user.Field == nil || ref.Field == nil {
+		return MetadataItem{}, false
+	}
+	if user.Field.Default == ref.Field.Default {
+		return MetadataItem{}, false
+	}
+	return MetadataItem{
+		Key:   user.Key,
+		Type:  "field",
+		Field: &FieldSpec{Default: user.Field.Default},
+	}, true
+}
+
+func mergeItem(base, patch MetadataItem) MetadataItem {
+	if base.Type != "field" || base.Field == nil || patch.Field == nil {
+		return base
+	}
+	merged := *base.Field
+	merged.Default = patch.Field.Default
+	out := base
+	out.Field = &merged
+	return out
 }

--- a/api/internal/registry/schema/registry.schema.json
+++ b/api/internal/registry/schema/registry.schema.json
@@ -1,0 +1,567 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/mr-pixel-kg/shopware-sandbox-plattform/master/api/internal/registry/schema/registry.schema.json",
+  "title": "Image Registry",
+  "description": "Catalogue of container images the API can launch as sandboxes. Used by editors for autocomplete and inline diagnostics; the Go loader in api/internal/registry performs the authoritative validation at runtime.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["images"],
+  "properties": {
+    "images": {
+      "title": "Images",
+      "description": "Image entries evaluated top-to-bottom; the first entry whose match glob matches an image reference wins.",
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/$defs/ImageEntry" }
+    }
+  },
+  "$defs": {
+    "Key": {
+      "title": "Identifier",
+      "description": "Lowercase identifier starting with a letter, followed by letters, digits, or underscores. Max 63 characters.",
+      "type": "string",
+      "pattern": "^[a-z][a-z0-9_]{0,62}$",
+      "examples": ["admin_user", "app_env", "open_admin"]
+    },
+    "Duration": {
+      "title": "Duration",
+      "description": "Duration string parsed by Go's time.ParseDuration. Units: ns, us, µs, ms, s, m, h.",
+      "type": "string",
+      "pattern": "^[0-9]+(ns|us|µs|ms|s|m|h)$",
+      "examples": ["500ms", "30s", "5m", "1h"]
+    },
+    "Context": {
+      "title": "UI Surface",
+      "description": "Named UI surface an item can render on. image.create = add-image dialog; image.edit = edit-image drawer; image.card = image tile in the explore/template list; sandbox.create = new-sandbox form; sandbox.card = sandbox tile in the user's sandbox list; sandbox.details = sandbox details and config tab.",
+      "type": "string",
+      "enum": [
+        "image.create",
+        "image.edit",
+        "image.card",
+        "sandbox.create",
+        "sandbox.card",
+        "sandbox.details"
+      ]
+    },
+    "ImageEntry": {
+      "title": "Image Entry",
+      "description": "Definition for one or more container images that share a match glob, runtime configuration, and metadata schema.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["match"],
+      "properties": {
+        "match": {
+          "title": "Match Glob",
+          "description": "Glob matched against image references (repo and optional tag). First matching entry in images wins.",
+          "type": "string",
+          "minLength": 1,
+          "examples": ["dockware/*", "dockware/dev:*", "ghcr.io/acme/shop-*"]
+        },
+        "internal_port": {
+          "title": "Container Port",
+          "description": "TCP port the container's primary HTTP service listens on. Used to wire the public URL and the health check.",
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 65535,
+          "examples": [80, 8080]
+        },
+        "ssh": { "$ref": "#/$defs/SSHEntry" },
+        "env": {
+          "title": "Environment Variables",
+          "description": "Environment variables injected into the container. Each value is a Go template rendered against the sandbox TemplateContext (e.g. {{.URL}}, {{.Hostname}}, {{.Meta.<key>}}).",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "labels": {
+          "title": "Docker Labels",
+          "description": "Docker labels applied to the container. Each value is a Go template rendered against the sandbox TemplateContext.",
+          "type": "object",
+          "additionalProperties": { "type": "string" }
+        },
+        "post_start": {
+          "title": "Post-Start Commands",
+          "description": "Commands executed inside the container after it starts, in declaration order. Later commands may rely on effects of earlier ones.",
+          "type": "array",
+          "items": { "$ref": "#/$defs/ExecCommand" }
+        },
+        "pre_stop": {
+          "title": "Pre-Stop Commands",
+          "description": "Commands executed inside the container before it stops, in declaration order.",
+          "type": "array",
+          "items": { "$ref": "#/$defs/ExecCommand" }
+        },
+        "health_check": { "$ref": "#/$defs/HealthCheck" },
+        "logs": {
+          "title": "Log Sources",
+          "description": "Log streams the UI can tail for sandboxes built from this image.",
+          "type": "array",
+          "items": { "$ref": "#/$defs/LogSource" }
+        },
+        "metadata": { "$ref": "#/$defs/MetadataSchema" }
+      }
+    },
+    "SSHEntry": {
+      "title": "SSH Defaults",
+      "description": "Default SSH credentials surfaced to users. Informational only; the platform does not configure or verify the SSH server.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["port", "username", "password"],
+      "properties": {
+        "port": {
+          "title": "Port",
+          "description": "Internal TCP port the SSH server listens on.",
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 65535,
+          "examples": [22]
+        },
+        "username": {
+          "title": "Username",
+          "description": "Default SSH username baked into the image.",
+          "type": "string",
+          "minLength": 1
+        },
+        "password": {
+          "title": "Password",
+          "description": "Default SSH password baked into the image.",
+          "type": "string"
+        }
+      }
+    },
+    "ExecCommand": {
+      "title": "Exec Command",
+      "description": "One command invocation with timing and retry behaviour. Shown as a step in the lifecycle log.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["command"],
+      "properties": {
+        "command": {
+          "title": "Command",
+          "description": "Argv array. Each element is a Go template rendered against the sandbox TemplateContext.",
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string" },
+          "examples": [["bash", "-c", "echo {{.Hostname}}"]]
+        },
+        "label": {
+          "title": "Label",
+          "description": "Human-readable step label shown in lifecycle log output.",
+          "type": "string"
+        },
+        "delay": {
+          "$ref": "#/$defs/Duration",
+          "title": "Initial Delay",
+          "description": "Wait before the first attempt."
+        },
+        "timeout": {
+          "$ref": "#/$defs/Duration",
+          "title": "Attempt Timeout",
+          "description": "Maximum duration of a single attempt before it is aborted."
+        },
+        "retries": {
+          "title": "Retries",
+          "description": "Additional attempts after the first failure. 0 means no retries.",
+          "type": "integer",
+          "minimum": 0
+        },
+        "retry_delay": {
+          "$ref": "#/$defs/Duration",
+          "title": "Retry Delay",
+          "description": "Wait between attempts."
+        }
+      }
+    },
+    "HealthCheck": {
+      "title": "Health Check",
+      "description": "HTTP GET probe against the container's internal_port. A sandbox is considered ready once the probe returns 2xx.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["path", "timeout", "interval"],
+      "properties": {
+        "path": {
+          "title": "Path",
+          "description": "HTTP path to probe.",
+          "type": "string",
+          "minLength": 1,
+          "examples": ["/api/_info/health-check"]
+        },
+        "timeout": {
+          "$ref": "#/$defs/Duration",
+          "title": "Request Timeout",
+          "description": "Maximum duration of a single probe request."
+        },
+        "interval": {
+          "$ref": "#/$defs/Duration",
+          "title": "Probe Interval",
+          "description": "Wait between probe attempts."
+        }
+      }
+    },
+    "LogSource": {
+      "title": "Log Source",
+      "description": "One tailable log stream exposed to the UI.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["key", "label", "type"],
+      "properties": {
+        "key": { "$ref": "#/$defs/Key" },
+        "label": {
+          "title": "Label",
+          "description": "Human-readable label shown in the log selector.",
+          "type": "string",
+          "minLength": 1
+        },
+        "type": {
+          "title": "Type",
+          "description": "Log source kind. docker = container stdout/stderr; file = file inside the container (requires path); lifecycle = platform-emitted post_start and pre_stop output.",
+          "type": "string",
+          "enum": ["docker", "file", "lifecycle"]
+        },
+        "path": {
+          "title": "File Path",
+          "description": "Absolute path inside the container. Required when type=file; must be omitted for docker and lifecycle.",
+          "type": "string"
+        }
+      }
+    },
+    "MetadataSchema": {
+      "title": "Metadata Schema",
+      "description": "Declares the fields, actions, and display values this image exposes to the UI.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["items"],
+      "properties": {
+        "groups": {
+          "title": "Groups",
+          "description": "Named sections used to group items in forms and detail views. Rendered in declaration order; referenced by an item's group key.",
+          "type": "array",
+          "items": { "$ref": "#/$defs/MetadataGroup" }
+        },
+        "items": {
+          "title": "Items",
+          "description": "Metadata entries. Each item is one of three variants discriminated by type: field (user-editable), action (link or button), or display (read-only value).",
+          "type": "array",
+          "items": { "$ref": "#/$defs/MetadataItem" }
+        }
+      }
+    },
+    "MetadataGroup": {
+      "title": "Metadata Group",
+      "description": "Labelled section of metadata items.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["key", "label"],
+      "properties": {
+        "key": { "$ref": "#/$defs/Key" },
+        "label": {
+          "title": "Label",
+          "description": "Section heading shown in the UI.",
+          "type": "string",
+          "minLength": 1
+        },
+        "description": {
+          "title": "Description",
+          "description": "Helper text shown beneath the section heading.",
+          "type": "string"
+        }
+      }
+    },
+    "FieldDependency": {
+      "title": "Field Dependency",
+      "description": "Shows the dependent item only when another field item's stored value equals value (exact string match).",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["field", "value"],
+      "properties": {
+        "field": {
+          "$ref": "#/$defs/Key",
+          "title": "Field Key",
+          "description": "Key of another field item in the same metadata schema."
+        },
+        "value": {
+          "title": "Value",
+          "description": "Required value of the referenced field for this item to render.",
+          "type": "string"
+        }
+      }
+    },
+    "Visibility": {
+      "title": "Visibility",
+      "description": "Controls where and when a metadata item renders.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "contexts": {
+          "title": "Contexts",
+          "description": "UI surfaces this item appears on. Omit or leave empty to render on every surface.",
+          "type": "array",
+          "uniqueItems": true,
+          "items": { "$ref": "#/$defs/Context" }
+        },
+        "condition": {
+          "title": "Runtime Condition",
+          "description": "Runtime gate evaluated by the frontend. Only \"ready\" is recognized today (disables the item until the sandbox reports ready); any other value is ignored.",
+          "type": "string",
+          "examples": ["ready"]
+        },
+        "depends_on": { "$ref": "#/$defs/FieldDependency" }
+      }
+    },
+    "SelectOption": {
+      "title": "Select Option",
+      "description": "One choice in a select or multiselect field.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["value", "label"],
+      "properties": {
+        "value": {
+          "title": "Value",
+          "description": "Stored value written to sandbox metadata.",
+          "type": "string"
+        },
+        "label": {
+          "title": "Label",
+          "description": "Label shown in the UI for this option.",
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "FieldSpec": {
+      "title": "Field",
+      "description": "User-editable input. Values are always stored as strings; booleans, numbers, and multiselect values use a string encoding on the wire.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["input"],
+      "properties": {
+        "input": {
+          "title": "Input Kind",
+          "description": "Rendered control and string-encoding convention. text = single-line text; password = masked single-line text; number = decimal string; email = email-validated text; url = url-validated text; select = one value from options; multiselect = comma-joined subset of options; toggle = \"true\" or \"false\"; textarea = multi-line text.",
+          "type": "string",
+          "enum": [
+            "text",
+            "password",
+            "number",
+            "email",
+            "url",
+            "select",
+            "multiselect",
+            "toggle",
+            "textarea"
+          ]
+        },
+        "default": {
+          "title": "Default",
+          "description": "Default value used when no sandbox value is set. Also feeds {{.Meta.<key>}} during template rendering.",
+          "type": "string"
+        },
+        "placeholder": {
+          "title": "Placeholder",
+          "description": "Placeholder text shown in empty inputs.",
+          "type": "string"
+        },
+        "help_text": {
+          "title": "Help Text",
+          "description": "Guidance rendered alongside the control and wired to aria-describedby.",
+          "type": "string"
+        },
+        "required": {
+          "title": "Required",
+          "description": "If true, the form cannot be submitted without a value.",
+          "type": "boolean"
+        },
+        "read_only": {
+          "title": "Read-Only",
+          "description": "If true, the value is displayed but not editable. Use for platform-assigned values.",
+          "type": "boolean"
+        },
+        "options": {
+          "title": "Options",
+          "description": "Available choices. Required and non-empty when input is select or multiselect; must be omitted for other input kinds.",
+          "type": "array",
+          "items": { "$ref": "#/$defs/SelectOption" }
+        }
+      }
+    },
+    "ActionSpec": {
+      "title": "Action",
+      "description": "Clickable link or button.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["url"],
+      "properties": {
+        "url": {
+          "title": "URL",
+          "description": "Go template producing an absolute URL, rendered server-side against the sandbox TemplateContext. Wrap user-controlled interpolations with urlquery, e.g. {{.URL}}/admin?u={{ urlquery .Meta.admin_user }}.",
+          "type": "string",
+          "minLength": 1,
+          "examples": ["{{.URL}}/admin"]
+        },
+        "variant": {
+          "title": "Variant",
+          "description": "Button visual style. default = primary; outline = secondary; destructive = danger (requires confirm).",
+          "type": "string",
+          "enum": ["default", "outline", "destructive"]
+        },
+        "size": {
+          "title": "Size",
+          "description": "Button size. default = standard; icon = compact icon-only.",
+          "type": "string",
+          "enum": ["default", "icon"]
+        },
+        "target": {
+          "title": "Target",
+          "description": "Anchor target. Defaults to _blank when omitted.",
+          "type": "string",
+          "enum": ["_blank", "_self"]
+        },
+        "confirm": {
+          "title": "Confirm Prompt",
+          "description": "Confirmation prompt shown before the action runs. Required when variant=destructive; ignored otherwise.",
+          "type": "string",
+          "examples": ["Dies löscht alle Shop-Daten. Fortfahren?"]
+        }
+      }
+    },
+    "DisplaySpec": {
+      "title": "Display",
+      "description": "Read-only value shown in the UI.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["value"],
+      "properties": {
+        "value": {
+          "title": "Value",
+          "description": "Go template rendered to a plain string server-side against the sandbox TemplateContext.",
+          "type": "string",
+          "minLength": 1,
+          "examples": ["{{.URL}}", "{{.Meta.admin_user}}"]
+        },
+        "format": {
+          "title": "Format",
+          "description": "Render style. text = plain text; code = monospace block; badge = status pill; link = clickable URL; password = masked with reveal toggle and treated as secret end-to-end.",
+          "type": "string",
+          "enum": ["text", "code", "badge", "link", "password"]
+        },
+        "copyable": {
+          "title": "Copyable",
+          "description": "Adds a copy-to-clipboard button next to the value.",
+          "type": "boolean"
+        }
+      }
+    },
+    "MetadataItem": {
+      "title": "Metadata Item",
+      "description": "One entry in metadata.items. Discriminated by type into a field, action, or display variant; exactly one of the matching sub-objects must be present.",
+      "oneOf": [
+        { "$ref": "#/$defs/FieldItem" },
+        { "$ref": "#/$defs/ActionItem" },
+        { "$ref": "#/$defs/DisplayItem" }
+      ]
+    },
+    "FieldItem": {
+      "title": "Field Item",
+      "description": "User-editable metadata item (type=field).",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["key", "label", "type", "field"],
+      "properties": {
+        "key": { "$ref": "#/$defs/Key" },
+        "label": {
+          "title": "Label",
+          "description": "Label shown next to the control.",
+          "type": "string",
+          "minLength": 1
+        },
+        "type": {
+          "title": "Type",
+          "description": "Discriminator. Must be \"field\".",
+          "type": "string",
+          "const": "field"
+        },
+        "icon": {
+          "title": "Icon",
+          "description": "Lucide icon name (e.g. user, lock, mail).",
+          "type": "string"
+        },
+        "group": {
+          "$ref": "#/$defs/Key",
+          "title": "Group",
+          "description": "Key of a metadata group declared in metadata.groups."
+        },
+        "visibility": { "$ref": "#/$defs/Visibility" },
+        "field": { "$ref": "#/$defs/FieldSpec" }
+      }
+    },
+    "ActionItem": {
+      "title": "Action Item",
+      "description": "Clickable link or button metadata item (type=action).",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["key", "label", "type", "action"],
+      "properties": {
+        "key": { "$ref": "#/$defs/Key" },
+        "label": {
+          "title": "Label",
+          "description": "Button or link text.",
+          "type": "string",
+          "minLength": 1
+        },
+        "type": {
+          "title": "Type",
+          "description": "Discriminator. Must be \"action\".",
+          "type": "string",
+          "const": "action"
+        },
+        "icon": {
+          "title": "Icon",
+          "description": "Lucide icon name (e.g. user, lock, mail).",
+          "type": "string"
+        },
+        "group": {
+          "$ref": "#/$defs/Key",
+          "title": "Group",
+          "description": "Key of a metadata group declared in metadata.groups."
+        },
+        "visibility": { "$ref": "#/$defs/Visibility" },
+        "action": { "$ref": "#/$defs/ActionSpec" }
+      }
+    },
+    "DisplayItem": {
+      "title": "Display Item",
+      "description": "Read-only metadata item (type=display).",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["key", "label", "type", "display"],
+      "properties": {
+        "key": { "$ref": "#/$defs/Key" },
+        "label": {
+          "title": "Label",
+          "description": "Label shown above or beside the value.",
+          "type": "string",
+          "minLength": 1
+        },
+        "type": {
+          "title": "Type",
+          "description": "Discriminator. Must be \"display\".",
+          "type": "string",
+          "const": "display"
+        },
+        "icon": {
+          "title": "Icon",
+          "description": "Lucide icon name (e.g. user, lock, mail).",
+          "type": "string"
+        },
+        "group": {
+          "$ref": "#/$defs/Key",
+          "title": "Group",
+          "description": "Key of a metadata group declared in metadata.groups."
+        },
+        "visibility": { "$ref": "#/$defs/Visibility" },
+        "display": { "$ref": "#/$defs/DisplaySpec" }
+      }
+    }
+  }
+}

--- a/api/internal/registry/validate.go
+++ b/api/internal/registry/validate.go
@@ -1,0 +1,283 @@
+package registry
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+	"text/template"
+)
+
+var keyRE = regexp.MustCompile(`^[a-z][a-z0-9_]{0,62}$`)
+
+type pathErrors struct {
+	errs []string
+}
+
+func (p *pathErrors) at(path, format string, args ...any) {
+	p.errs = append(p.errs, fmt.Sprintf("%s: %s", path, fmt.Sprintf(format, args...)))
+}
+
+func (p *pathErrors) err() error {
+	if len(p.errs) == 0 {
+		return nil
+	}
+	return fmt.Errorf("registry validation failed:\n  - %s", strings.Join(p.errs, "\n  - "))
+}
+
+func validateRegistry(reg *ImageRegistry) error {
+	pe := &pathErrors{}
+	if len(reg.Images) == 0 {
+		pe.at("registry", "must contain at least one image entry")
+		return pe.err()
+	}
+
+	for i := range reg.Images {
+		img := &reg.Images[i]
+		base := fmt.Sprintf("images[%d]", i)
+
+		if img.Match == "" {
+			pe.at(base, "match pattern is required")
+		}
+
+		for j, cmd := range img.PostStart {
+			if len(cmd.Command) == 0 {
+				pe.at(fmt.Sprintf("%s.post_start[%d]", base, j), "command must not be empty")
+			}
+		}
+		for j, cmd := range img.PreStop {
+			if len(cmd.Command) == 0 {
+				pe.at(fmt.Sprintf("%s.pre_stop[%d]", base, j), "command must not be empty")
+			}
+		}
+
+		validateMetadata(base+".metadata", &img.Metadata, pe)
+		validateLogs(base, img.Logs, pe)
+	}
+
+	return pe.err()
+}
+
+func validateMetadata(base string, schema *MetadataSchema, pe *pathErrors) {
+	groupKeys := map[string]bool{}
+	seenGroups := map[string]bool{}
+	for i, g := range schema.Groups {
+		p := fmt.Sprintf("%s.groups[%d] (key=%q)", base, i, g.Key)
+		if g.Key == "" || !keyRE.MatchString(g.Key) {
+			pe.at(p, "group key must match ^[a-z][a-z0-9_]{0,62}$")
+			continue
+		}
+		if g.Key == "_default" {
+			pe.at(p, "group key %q is reserved", g.Key)
+		}
+		if g.Label == "" {
+			pe.at(p, "group label is required")
+		}
+		if seenGroups[g.Key] {
+			pe.at(p, "duplicate group key %q", g.Key)
+		}
+		seenGroups[g.Key] = true
+		groupKeys[g.Key] = true
+	}
+
+	fieldOptions := map[string][]string{}
+	seenItems := map[string]bool{}
+	for i := range schema.Items {
+		it := &schema.Items[i]
+		if it.Key != "" && keyRE.MatchString(it.Key) && it.Type == "field" && it.Field != nil {
+			if it.Field.Input == "select" || it.Field.Input == "multiselect" {
+				vals := make([]string, 0, len(it.Field.Options))
+				for _, o := range it.Field.Options {
+					vals = append(vals, o.Value)
+				}
+				fieldOptions[it.Key] = vals
+			} else {
+				fieldOptions[it.Key] = nil
+			}
+		}
+	}
+
+	for i := range schema.Items {
+		it := &schema.Items[i]
+		p := fmt.Sprintf("%s.items[%d] (key=%q)", base, i, it.Key)
+
+		if it.Key == "" || !keyRE.MatchString(it.Key) {
+			pe.at(p, "item key must match ^[a-z][a-z0-9_]{0,62}$")
+		}
+		if it.Label == "" {
+			pe.at(p, "label is required")
+		}
+		if seenItems[it.Key] {
+			pe.at(p, "duplicate item key %q", it.Key)
+		}
+		seenItems[it.Key] = true
+
+		if !ValidItemTypes[it.Type] {
+			pe.at(p, "type must be one of field|action|display, got %q", it.Type)
+		}
+
+		setCount := 0
+		if it.Field != nil {
+			setCount++
+		}
+		if it.Action != nil {
+			setCount++
+		}
+		if it.Display != nil {
+			setCount++
+		}
+		if setCount != 1 {
+			pe.at(p, "exactly one of field/action/display must be set (found %d)", setCount)
+		}
+		if it.Type == "field" && it.Field == nil {
+			pe.at(p, "type=field requires field sub-object")
+		}
+		if it.Type == "action" && it.Action == nil {
+			pe.at(p, "type=action requires action sub-object")
+		}
+		if it.Type == "display" && it.Display == nil {
+			pe.at(p, "type=display requires display sub-object")
+		}
+
+		if it.Group != "" && !groupKeys[it.Group] {
+			pe.at(p, "group %q is not declared in metadata.groups", it.Group)
+		}
+
+		validateVisibility(p, it.Visibility, fieldOptions, pe)
+
+		if it.Field != nil {
+			validateFieldSpec(p+".field", it.Field, pe)
+		}
+		if it.Action != nil {
+			validateActionSpec(p+".action", it.Action, pe)
+		}
+		if it.Display != nil {
+			validateDisplaySpec(p+".display", it.Display, pe)
+		}
+	}
+}
+
+func validateVisibility(base string, v *VisibilityRule, fieldOptions map[string][]string, pe *pathErrors) {
+	if v == nil {
+		return
+	}
+	for i, ctx := range v.Contexts {
+		if !ValidContexts[ctx] {
+			pe.at(fmt.Sprintf("%s.visibility.contexts[%d]", base, i), "unknown context %q", ctx)
+		}
+	}
+	if v.DependsOn != nil {
+		p := base + ".visibility.depends_on"
+		if v.DependsOn.Field == "" {
+			pe.at(p, "field is required")
+		} else {
+			opts, ok := fieldOptions[v.DependsOn.Field]
+			if !ok {
+				pe.at(p, "field %q does not reference a defined field item", v.DependsOn.Field)
+			} else if len(opts) > 0 {
+				found := false
+				for _, o := range opts {
+					if o == v.DependsOn.Value {
+						found = true
+						break
+					}
+				}
+				if !found {
+					pe.at(p, "value %q is not one of field %q options", v.DependsOn.Value, v.DependsOn.Field)
+				}
+			}
+		}
+	}
+}
+
+func validateFieldSpec(base string, f *FieldSpec, pe *pathErrors) {
+	if !ValidFieldInputs[f.Input] {
+		pe.at(base, "input must be one of text|password|number|email|url|select|multiselect|toggle|textarea, got %q", f.Input)
+	}
+	if f.Input == "select" || f.Input == "multiselect" {
+		if len(f.Options) == 0 {
+			pe.at(base+".options", "must be non-empty when input=%s", f.Input)
+		}
+		seen := map[string]bool{}
+		for i, o := range f.Options {
+			if o.Value == "" {
+				pe.at(fmt.Sprintf("%s.options[%d]", base, i), "value is required")
+			}
+			if o.Label == "" {
+				pe.at(fmt.Sprintf("%s.options[%d]", base, i), "label is required")
+			}
+			if seen[o.Value] {
+				pe.at(fmt.Sprintf("%s.options[%d]", base, i), "duplicate option value %q", o.Value)
+			}
+			seen[o.Value] = true
+		}
+	} else if len(f.Options) > 0 {
+		pe.at(base+".options", "must be empty unless input=select|multiselect")
+	}
+}
+
+func validateActionSpec(base string, a *ActionSpec, pe *pathErrors) {
+	if a.URL == "" {
+		pe.at(base+".url", "is required")
+	} else {
+		tmpl, err := template.New("url").Option("missingkey=error").Parse(a.URL)
+		if err != nil {
+			pe.at(base+".url", "template parse error: %v", err)
+		} else {
+			a.urlTmpl = tmpl
+		}
+	}
+	if a.Variant != "" && !ValidActionVariants[a.Variant] {
+		pe.at(base+".variant", "must be one of default|outline|destructive, got %q", a.Variant)
+	}
+	if a.Size != "" && !ValidActionSizes[a.Size] {
+		pe.at(base+".size", "must be one of default|icon, got %q", a.Size)
+	}
+	if a.Target != "" && !ValidActionTargets[a.Target] {
+		pe.at(base+".target", "must be one of _blank|_self, got %q", a.Target)
+	}
+	if a.Variant == "destructive" && a.Confirm == "" {
+		pe.at(base+".confirm", "is required when variant=destructive")
+	}
+}
+
+func validateDisplaySpec(base string, d *DisplaySpec, pe *pathErrors) {
+	if d.Value == "" {
+		pe.at(base+".value", "is required")
+		return
+	}
+	if d.Format != "" && !ValidDisplayFormats[d.Format] {
+		pe.at(base+".format", "must be one of text|code|badge|link|password, got %q", d.Format)
+	}
+	tmpl, err := template.New("display").Option("missingkey=error").Parse(d.Value)
+	if err != nil {
+		pe.at(base+".value", "template parse error: %v", err)
+	} else {
+		d.valueTmpl = tmpl
+	}
+}
+
+func validateLogs(base string, logs []LogSource, pe *pathErrors) {
+	seen := map[string]bool{}
+	for j, ls := range logs {
+		p := fmt.Sprintf("%s.logs[%d]", base, j)
+		if ls.Key == "" {
+			pe.at(p, "key is required")
+		}
+		if ls.Label == "" {
+			pe.at(p, "label is required")
+		}
+		if ls.Type != LogSourceTypeDocker && ls.Type != LogSourceTypeFile && ls.Type != LogSourceTypeLifecycle {
+			pe.at(p, "type must be docker|file|lifecycle, got %q", ls.Type)
+		}
+		if ls.Type == LogSourceTypeFile && ls.Path == "" {
+			pe.at(p, "path is required for file log sources")
+		}
+		if (ls.Type == LogSourceTypeDocker || ls.Type == LogSourceTypeLifecycle) && ls.Path != "" {
+			pe.at(p, "path must not be set for %s log sources", ls.Type)
+		}
+		if seen[ls.Key] {
+			pe.at(p, "duplicate key %q", ls.Key)
+		}
+		seen[ls.Key] = true
+	}
+}

--- a/api/internal/registry/validate.go
+++ b/api/internal/registry/validate.go
@@ -57,6 +57,87 @@ func validateRegistry(reg *ImageRegistry) error {
 	return pe.err()
 }
 
+func ValidateMetadata(metadata []MetadataItem, registrySchema *MetadataSchema) error {
+	pe := &pathErrors{}
+	groupKeys := map[string]bool{}
+	if registrySchema != nil {
+		for _, g := range registrySchema.Groups {
+			groupKeys[g.Key] = true
+		}
+	}
+
+	fieldOptions := map[string][]string{}
+	seenItems := map[string]bool{}
+	for i := range metadata {
+		it := &metadata[i]
+		if it.Key != "" && keyRE.MatchString(it.Key) && it.Type == "field" && it.Field != nil {
+			if it.Field.Input == "select" || it.Field.Input == "multiselect" {
+				vals := make([]string, 0, len(it.Field.Options))
+				for _, o := range it.Field.Options {
+					vals = append(vals, o.Value)
+				}
+				fieldOptions[it.Key] = vals
+			} else {
+				fieldOptions[it.Key] = nil
+			}
+		}
+	}
+
+	for i := range metadata {
+		it := &metadata[i]
+		p := fmt.Sprintf("metadata[%d] (key=%q)", i, it.Key)
+		if it.Key == "" || !keyRE.MatchString(it.Key) {
+			pe.at(p, "item key must match ^[a-z][a-z0-9_]{0,62}$")
+		}
+		if seenItems[it.Key] {
+			pe.at(p, "duplicate item key %q", it.Key)
+		}
+		seenItems[it.Key] = true
+		if it.Label == "" {
+			pe.at(p, "label is required")
+		}
+		if !ValidItemTypes[it.Type] {
+			pe.at(p, "type must be one of field|action|display, got %q", it.Type)
+		}
+		setCount := 0
+		if it.Field != nil {
+			setCount++
+		}
+		if it.Action != nil {
+			setCount++
+		}
+		if it.Display != nil {
+			setCount++
+		}
+		if setCount != 1 {
+			pe.at(p, "exactly one of field/action/display must be set (found %d)", setCount)
+		}
+		if it.Type == "field" && it.Field == nil {
+			pe.at(p, "type=field requires field sub-object")
+		}
+		if it.Type == "action" && it.Action == nil {
+			pe.at(p, "type=action requires action sub-object")
+		}
+		if it.Type == "display" && it.Display == nil {
+			pe.at(p, "type=display requires display sub-object")
+		}
+		if it.Group != "" && !groupKeys[it.Group] {
+			pe.at(p, "group %q is not declared in the registry schema", it.Group)
+		}
+		validateVisibility(p, it.Visibility, fieldOptions, pe)
+		if it.Field != nil {
+			validateFieldSpec(p+".field", it.Field, pe)
+		}
+		if it.Action != nil {
+			validateActionSpec(p+".action", it.Action, pe)
+		}
+		if it.Display != nil {
+			validateDisplaySpec(p+".display", it.Display, pe)
+		}
+	}
+	return pe.err()
+}
+
 func validateMetadata(base string, schema *MetadataSchema, pe *pathErrors) {
 	groupKeys := map[string]bool{}
 	seenGroups := map[string]bool{}

--- a/api/internal/registry/values.go
+++ b/api/internal/registry/values.go
@@ -38,17 +38,6 @@ func ValuesToJSONMap(m map[string]string) map[string]any {
 	return out
 }
 
-func MergeValues(base, override map[string]string) map[string]string {
-	out := make(map[string]string, len(base)+len(override))
-	for k, v := range base {
-		out[k] = v
-	}
-	for k, v := range override {
-		out[k] = v
-	}
-	return out
-}
-
 func HostnameFromURL(u string) string {
 	if u == "" {
 		return ""

--- a/api/internal/registry/values.go
+++ b/api/internal/registry/values.go
@@ -1,0 +1,64 @@
+package registry
+
+import (
+	"fmt"
+	"log/slog"
+	"strings"
+)
+
+func ValuesFromJSONMap(m map[string]any) map[string]string {
+	if len(m) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(m))
+	for k, v := range m {
+		switch t := v.(type) {
+		case nil:
+			continue
+		case string:
+			out[k] = t
+		case bool,
+			float64, float32,
+			int, int32, int64,
+			uint, uint32, uint64:
+			out[k] = fmt.Sprint(t)
+		default:
+			slog.Debug("metadata value dropped: unsupported type",
+				"component", "registry", "key", k, "type", fmt.Sprintf("%T", v))
+		}
+	}
+	return out
+}
+
+func ValuesToJSONMap(m map[string]string) map[string]any {
+	out := make(map[string]any, len(m))
+	for k, v := range m {
+		out[k] = v
+	}
+	return out
+}
+
+func MergeValues(base, override map[string]string) map[string]string {
+	out := make(map[string]string, len(base)+len(override))
+	for k, v := range base {
+		out[k] = v
+	}
+	for k, v := range override {
+		out[k] = v
+	}
+	return out
+}
+
+func HostnameFromURL(u string) string {
+	if u == "" {
+		return ""
+	}
+	s := u
+	if i := strings.Index(s, "://"); i >= 0 {
+		s = s[i+3:]
+	}
+	if i := strings.IndexAny(s, "/?#"); i >= 0 {
+		s = s[:i]
+	}
+	return s
+}

--- a/api/internal/repositories/sandbox_repository.go
+++ b/api/internal/repositories/sandbox_repository.go
@@ -51,7 +51,7 @@ func (r *SandboxRepository) FindByID(id uuid.UUID) (*models.Sandbox, error) {
 
 func (r *SandboxRepository) FindByContainerID(containerID string) (*models.Sandbox, error) {
 	var sandbox models.Sandbox
-	if err := r.db.First(&sandbox, "container_id = ?", containerID).Error; err != nil {
+	if err := r.db.Where("deleted_at IS NULL").First(&sandbox, "container_id = ?", containerID).Error; err != nil {
 		return nil, err
 	}
 	return &sandbox, nil

--- a/api/internal/services/image_service.go
+++ b/api/internal/services/image_service.go
@@ -2,7 +2,6 @@ package services
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"io"
 	"log/slog"
@@ -19,7 +18,6 @@ import (
 	"github.com/mr-pixel-kg/shopshredder/api/internal/models"
 	"github.com/mr-pixel-kg/shopshredder/api/internal/registry"
 	"github.com/mr-pixel-kg/shopshredder/api/internal/repositories"
-	"gorm.io/datatypes"
 )
 
 const (
@@ -117,7 +115,6 @@ func (s *ImageService) ListAllPaginated(input ImageListInput) (*ImageListResult,
 		return nil, err
 	}
 	images = s.attachThumbnailURLs(images)
-	s.enrichMetadata(images)
 	return &ImageListResult{
 		Images: images,
 		Total:  total,
@@ -132,7 +129,6 @@ func (s *ImageService) ListPublicPaginated(input ImageListInput) (*ImageListResu
 		return nil, err
 	}
 	images = s.attachThumbnailURLs(images)
-	s.enrichMetadata(images)
 	return &ImageListResult{
 		Images: images,
 		Total:  total,
@@ -146,9 +142,7 @@ func (s *ImageService) ListPublic() ([]models.Image, error) {
 	if err != nil {
 		return nil, err
 	}
-	images = s.attachThumbnailURLs(images)
-	s.enrichMetadata(images)
-	return images, nil
+	return s.attachThumbnailURLs(images), nil
 }
 
 func (s *ImageService) ListAll() ([]models.Image, error) {
@@ -156,9 +150,7 @@ func (s *ImageService) ListAll() ([]models.Image, error) {
 	if err != nil {
 		return nil, err
 	}
-	images = s.attachThumbnailURLs(images)
-	s.enrichMetadata(images)
-	return images, nil
+	return s.attachThumbnailURLs(images), nil
 }
 
 func (s *ImageService) FindByID(id uuid.UUID) (*models.Image, error) {
@@ -166,18 +158,14 @@ func (s *ImageService) FindByID(id uuid.UUID) (*models.Image, error) {
 	if err != nil {
 		return nil, err
 	}
-	image = s.attachThumbnailURL(image)
-	images := []models.Image{*image}
-	s.enrichMetadata(images)
-	*image = images[0]
-	return image, nil
+	return s.attachThumbnailURL(image), nil
 }
 
 func (s *ImageService) FindByIDs(ids []uuid.UUID) ([]models.Image, error) {
 	return s.repo.FindByIDs(ids)
 }
 
-func (s *ImageService) createImage(userID *uuid.UUID, name, tag string, title, description *string, isPublic bool, metadata json.RawMessage, registryRef *string, status string) (*models.Image, error) {
+func (s *ImageService) createImage(userID *uuid.UUID, name, tag string, title, description *string, isPublic bool, metadata map[string]string, registryRef *string, status string) (*models.Image, error) {
 	img := &models.Image{
 		ID:          uuid.New(),
 		Name:        name,
@@ -187,7 +175,7 @@ func (s *ImageService) createImage(userID *uuid.UUID, name, tag string, title, d
 		IsPublic:    isPublic,
 		Status:      status,
 		OwnerID:     userID,
-		Metadata:    guardJSON(metadata, []byte("[]")),
+		Metadata:    registry.ValuesToJSONMap(metadata),
 		RegistryRef: registryRef,
 	}
 
@@ -204,7 +192,7 @@ func (s *ImageService) CreateForUser(
 	name, tag string,
 	title, description *string,
 	isPublic bool,
-	metadata json.RawMessage,
+	metadata map[string]string,
 	registryRef *string,
 ) (*models.Image, error) {
 	img, err := s.createImage(userID, name, tag, title, description, isPublic, metadata, registryRef, models.ImageStatusPulling)
@@ -218,12 +206,10 @@ func (s *ImageService) CreateForUser(
 		if err := s.repo.UpdateStatus(img.ID, models.ImageStatusReady, nil); err != nil {
 			slog.Error("failed to mark image as ready", "component", "image", "image_id", img.ID.String(), "error", err.Error())
 		}
-		s.enrichMetadata([]models.Image{*img})
 		return img, nil
 	}
 
 	s.startPull(img.ID, fullName)
-	s.enrichMetadata([]models.Image{*img})
 	return img, nil
 }
 
@@ -290,7 +276,7 @@ func (s *ImageService) WatchPullProgress(imageID string) (<-chan docker.PullProg
 	return s.tracker.Watch(imageID)
 }
 
-func (s *ImageService) Update(id uuid.UUID, title, description *string, isPublic bool, metadata json.RawMessage) (*models.Image, error) {
+func (s *ImageService) Update(id uuid.UUID, title, description *string, isPublic bool, metadata map[string]string) (*models.Image, error) {
 	image, err := s.repo.FindByID(id)
 	if err != nil {
 		return nil, err
@@ -300,17 +286,13 @@ func (s *ImageService) Update(id uuid.UUID, title, description *string, isPublic
 	image.Description = description
 	image.IsPublic = isPublic
 	if metadata != nil {
-		image.Metadata = datatypes.JSON(metadata)
+		image.Metadata = registry.ValuesToJSONMap(metadata)
 	}
 	if err := s.repo.Update(image); err != nil {
 		return nil, err
 	}
 
-	image = s.attachThumbnailURL(image)
-	images := []models.Image{*image}
-	s.enrichMetadata(images)
-	*image = images[0]
-	return image, nil
+	return s.attachThumbnailURL(image), nil
 }
 
 func (s *ImageService) SaveThumbnail(id uuid.UUID, file multipart.File, originalFilename, contentType string) (*models.Image, error) {
@@ -346,9 +328,7 @@ func (s *ImageService) SaveThumbnail(id uuid.UUID, file multipart.File, original
 		return nil, err
 	}
 
-	image = s.attachThumbnailURL(image)
-	s.enrichMetadata([]models.Image{*image})
-	return image, nil
+	return s.attachThumbnailURL(image), nil
 }
 
 func (s *ImageService) DeleteThumbnail(id uuid.UUID) (*models.Image, error) {
@@ -394,7 +374,7 @@ func (s *ImageService) CreateForCommit(
 	name, tag string,
 	title, description *string,
 	isPublic bool,
-	metadata json.RawMessage,
+	metadata map[string]string,
 	registryRef *string,
 ) (*models.Image, error) {
 	return s.createImage(userID, name, tag, title, description, isPublic, metadata, registryRef, models.ImageStatusCommitting)
@@ -470,13 +450,6 @@ func (s *ImageService) Delete(ctx context.Context, id uuid.UUID) error {
 	}
 
 	return s.repo.Delete(id)
-}
-
-func guardJSON(data []byte, fallback []byte) datatypes.JSON {
-	if data == nil || string(data) == "null" {
-		return datatypes.JSON(fallback)
-	}
-	return datatypes.JSON(data)
 }
 
 func (s *ImageService) attachThumbnailURLs(images []models.Image) []models.Image {
@@ -573,19 +546,27 @@ func extensionForContentType(contentType string) string {
 	}
 }
 
-func (s *ImageService) enrichMetadata(images []models.Image) {
+func (s *ImageService) EnrichMetadata(images []models.Image) map[uuid.UUID]*registry.MetadataSchema {
+	out := make(map[uuid.UUID]*registry.MetadataSchema, len(images))
 	if s.resolver == nil {
-		return
+		return out
 	}
 	for i := range images {
-		entry := s.resolver.ResolveEntry(images[i].RegistryName())
-		if entry == nil {
+		img := &images[i]
+		schema, err := s.resolver.RenderMetadata(
+			img.RegistryName(),
+			registry.ValuesFromJSONMap(img.Metadata),
+			registry.TemplateContext{},
+		)
+		if err != nil {
+			slog.Error("metadata render failed",
+				"component", "registry",
+				"image_id", img.ID,
+				"registry_match", img.RegistryName(),
+				"error", err)
 			continue
 		}
-		reg := make([]registry.MetadataItem, len(entry.Metadata))
-		copy(reg, entry.Metadata)
-		merged := mergeRegistryAndDB(reg, images[i].Metadata)
-		data, _ := json.Marshal(merged)
-		images[i].Metadata = datatypes.JSON(data)
+		out[img.ID] = schema
 	}
+	return out
 }

--- a/api/internal/services/image_service.go
+++ b/api/internal/services/image_service.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"io"
 	"log/slog"
@@ -14,10 +15,12 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/mr-pixel-kg/shopshredder/api/internal/apperror"
 	"github.com/mr-pixel-kg/shopshredder/api/internal/docker"
 	"github.com/mr-pixel-kg/shopshredder/api/internal/models"
 	"github.com/mr-pixel-kg/shopshredder/api/internal/registry"
 	"github.com/mr-pixel-kg/shopshredder/api/internal/repositories"
+	"gorm.io/datatypes"
 )
 
 const (
@@ -165,7 +168,7 @@ func (s *ImageService) FindByIDs(ids []uuid.UUID) ([]models.Image, error) {
 	return s.repo.FindByIDs(ids)
 }
 
-func (s *ImageService) createImage(userID *uuid.UUID, name, tag string, title, description *string, isPublic bool, metadata map[string]string, registryRef *string, status string) (*models.Image, error) {
+func (s *ImageService) createImage(userID *uuid.UUID, name, tag string, title, description *string, isPublic bool, metadata []registry.MetadataItem, registryRef *string, status string) (*models.Image, error) {
 	img := &models.Image{
 		ID:          uuid.New(),
 		Name:        name,
@@ -175,9 +178,13 @@ func (s *ImageService) createImage(userID *uuid.UUID, name, tag string, title, d
 		IsPublic:    isPublic,
 		Status:      status,
 		OwnerID:     userID,
-		Metadata:    registry.ValuesToJSONMap(metadata),
 		RegistryRef: registryRef,
 	}
+	encoded, err := s.encodeMetadata(img, metadata)
+	if err != nil {
+		return nil, err
+	}
+	img.Metadata = encoded
 
 	if err := s.repo.Create(img); err != nil {
 		return nil, err
@@ -186,13 +193,27 @@ func (s *ImageService) createImage(userID *uuid.UUID, name, tag string, title, d
 	return s.attachThumbnailURL(img), nil
 }
 
+func (s *ImageService) encodeMetadata(img *models.Image, metadata []registry.MetadataItem) (datatypes.JSON, error) {
+	schema := s.resolver.SchemaFor(img.RegistryName())
+	if err := registry.ValidateMetadata(registry.MergeWithRegistry(schema, metadata), schema); err != nil {
+		return nil, apperror.BadRequest("INVALID_METADATA", err.Error())
+	}
+	return json.Marshal(registry.StripRegistryDuplicates(metadata, schema))
+}
+
+func decodeMetadata(raw datatypes.JSON) []registry.MetadataItem {
+	var metadata []registry.MetadataItem
+	_ = json.Unmarshal(raw, &metadata)
+	return metadata
+}
+
 func (s *ImageService) CreateForUser(
 	ctx context.Context,
 	userID *uuid.UUID,
 	name, tag string,
 	title, description *string,
 	isPublic bool,
-	metadata map[string]string,
+	metadata []registry.MetadataItem,
 	registryRef *string,
 ) (*models.Image, error) {
 	img, err := s.createImage(userID, name, tag, title, description, isPublic, metadata, registryRef, models.ImageStatusPulling)
@@ -276,7 +297,7 @@ func (s *ImageService) WatchPullProgress(imageID string) (<-chan docker.PullProg
 	return s.tracker.Watch(imageID)
 }
 
-func (s *ImageService) Update(id uuid.UUID, title, description *string, isPublic bool, metadata map[string]string) (*models.Image, error) {
+func (s *ImageService) Update(id uuid.UUID, title, description *string, isPublic bool, metadata []registry.MetadataItem) (*models.Image, error) {
 	image, err := s.repo.FindByID(id)
 	if err != nil {
 		return nil, err
@@ -286,7 +307,11 @@ func (s *ImageService) Update(id uuid.UUID, title, description *string, isPublic
 	image.Description = description
 	image.IsPublic = isPublic
 	if metadata != nil {
-		image.Metadata = registry.ValuesToJSONMap(metadata)
+		encoded, err := s.encodeMetadata(image, metadata)
+		if err != nil {
+			return nil, err
+		}
+		image.Metadata = encoded
 	}
 	if err := s.repo.Update(image); err != nil {
 		return nil, err
@@ -374,7 +399,7 @@ func (s *ImageService) CreateForCommit(
 	name, tag string,
 	title, description *string,
 	isPublic bool,
-	metadata map[string]string,
+	metadata []registry.MetadataItem,
 	registryRef *string,
 ) (*models.Image, error) {
 	return s.createImage(userID, name, tag, title, description, isPublic, metadata, registryRef, models.ImageStatusCommitting)
@@ -428,7 +453,15 @@ func (s *ImageService) Delete(ctx context.Context, id uuid.UUID) error {
 	}
 
 	for _, sb := range sandboxes {
-		if sb.Status == models.SandboxStatusStarting || sb.Status == models.SandboxStatusRunning {
+		wasActive := sb.Status == models.SandboxStatusStarting || sb.Status == models.SandboxStatusRunning
+		now := time.Now().UTC()
+		sb.Status = models.SandboxStatusDeleted
+		sb.StateReason = nil
+		sb.DeletedAt = &now
+		if err := s.sandboxRepo.Update(&sb); err != nil {
+			slog.Warn("mark sandbox deleted during image deletion failed", "component", "image", "sandbox_id", sb.ID.String(), "error", err.Error())
+		}
+		if wasActive {
 			if err := s.docker.DeleteContainer(ctx, sb.ContainerID); err != nil {
 				slog.Warn("failed to delete sandbox container during image deletion", "component", "image", "container_id", sb.ContainerID, "error", err.Error())
 			}
@@ -546,27 +579,11 @@ func extensionForContentType(contentType string) string {
 	}
 }
 
-func (s *ImageService) EnrichMetadata(images []models.Image) map[uuid.UUID]*registry.MetadataSchema {
-	out := make(map[uuid.UUID]*registry.MetadataSchema, len(images))
-	if s.resolver == nil {
-		return out
-	}
+func (s *ImageService) EnrichMetadata(images []models.Image) map[uuid.UUID][]registry.MetadataItem {
+	out := make(map[uuid.UUID][]registry.MetadataItem, len(images))
 	for i := range images {
 		img := &images[i]
-		schema, err := s.resolver.RenderMetadata(
-			img.RegistryName(),
-			registry.ValuesFromJSONMap(img.Metadata),
-			registry.TemplateContext{},
-		)
-		if err != nil {
-			slog.Error("metadata render failed",
-				"component", "registry",
-				"image_id", img.ID,
-				"registry_match", img.RegistryName(),
-				"error", err)
-			continue
-		}
-		out[img.ID] = schema
+		out[img.ID] = s.resolver.MergeMetadata(img.RegistryName(), decodeMetadata(img.Metadata))
 	}
 	return out
 }

--- a/api/internal/services/sandbox_service.go
+++ b/api/internal/services/sandbox_service.go
@@ -512,7 +512,7 @@ type CreateSnapshotInput struct {
 	IsPublic    bool
 	ClientIP    string
 	UserID      *uuid.UUID
-	Metadata    map[string]string
+	Metadata    []registry.MetadataItem
 	AuditActor  AuditActor
 }
 
@@ -984,7 +984,7 @@ func (s *SandboxService) ResolveSSHEntry(imageID uuid.UUID) *registry.SSHEntry {
 
 type SandboxEnrichment struct {
 	SSH      *registry.SSHEntry
-	Metadata *registry.MetadataSchema
+	Metadata []registry.MetadataItem
 }
 
 func (s *SandboxService) EnrichMetadata(sandboxes []models.Sandbox) map[uuid.UUID]SandboxEnrichment {
@@ -1001,7 +1001,7 @@ func (s *SandboxService) EnrichMetadata(sandboxes []models.Sandbox) map[uuid.UUI
 
 	type imageCache struct {
 		registryName string
-		values       map[string]string
+		metadata     []registry.MetadataItem
 		ssh          *registry.SSHEntry
 	}
 	cache := make(map[uuid.UUID]imageCache, len(imageIDs))
@@ -1015,7 +1015,7 @@ func (s *SandboxService) EnrichMetadata(sandboxes []models.Sandbox) map[uuid.UUI
 		img := &images[i]
 		c := imageCache{
 			registryName: img.RegistryName(),
-			values:       registry.ValuesFromJSONMap(img.Metadata),
+			metadata:     decodeMetadata(img.Metadata),
 		}
 		if entry := s.resolver.ResolveEntry(c.registryName); entry != nil {
 			c.ssh = entry.SSH
@@ -1029,7 +1029,7 @@ func (s *SandboxService) EnrichMetadata(sandboxes []models.Sandbox) map[uuid.UUI
 		if !ok {
 			continue
 		}
-		values := registry.MergeValues(c.values, registry.ValuesFromJSONMap(sb.Metadata))
+		values := registry.ValuesFromJSONMap(sb.Metadata)
 		tctx := registry.TemplateContext{
 			Hostname:      registry.HostnameFromURL(sb.GetURL()),
 			URL:           sb.GetURL(),
@@ -1039,7 +1039,7 @@ func (s *SandboxService) EnrichMetadata(sandboxes []models.Sandbox) map[uuid.UUI
 			Status:        string(sb.Status),
 			ClientIP:      sb.ClientIP,
 		}
-		schema, err := s.resolver.RenderMetadata(c.registryName, values, tctx)
+		schema, err := s.resolver.RenderMetadata(c.registryName, values, c.metadata, tctx)
 		if err != nil {
 			slog.Error("metadata render failed",
 				"component", "registry",

--- a/api/internal/services/sandbox_service.go
+++ b/api/internal/services/sandbox_service.go
@@ -98,39 +98,19 @@ type UpdateSandboxInput struct {
 }
 
 func (s *SandboxService) ListAll() ([]models.Sandbox, error) {
-	sandboxes, err := s.repo.ListAll()
-	if err != nil {
-		return nil, err
-	}
-	s.EnrichMetadata(sandboxes)
-	return sandboxes, nil
+	return s.repo.ListAll()
 }
 
 func (s *SandboxService) ListActive() ([]models.Sandbox, error) {
-	sandboxes, err := s.repo.ListAllActive()
-	if err != nil {
-		return nil, err
-	}
-	s.EnrichMetadata(sandboxes)
-	return sandboxes, nil
+	return s.repo.ListAllActive()
 }
 
 func (s *SandboxService) ListByUser(userID uuid.UUID) ([]models.Sandbox, error) {
-	sandboxes, err := s.repo.ListAllByUser(userID)
-	if err != nil {
-		return nil, err
-	}
-	s.EnrichMetadata(sandboxes)
-	return sandboxes, nil
+	return s.repo.ListAllByUser(userID)
 }
 
 func (s *SandboxService) ListByClientID(clientID uuid.UUID) ([]models.Sandbox, error) {
-	sandboxes, err := s.repo.ListAllByClientID(clientID)
-	if err != nil {
-		return nil, err
-	}
-	s.EnrichMetadata(sandboxes)
-	return sandboxes, nil
+	return s.repo.ListAllByClientID(clientID)
 }
 
 type SandboxListInput struct {
@@ -141,11 +121,10 @@ type SandboxListInput struct {
 }
 
 type SandboxListResult struct {
-	Sandboxes  []models.Sandbox
-	SSHEntries map[uuid.UUID]*registry.SSHEntry
-	Total      int64
-	Limit      int
-	Offset     int
+	Sandboxes []models.Sandbox
+	Total     int64
+	Limit     int
+	Offset    int
 }
 
 func (s *SandboxService) ListPaginated(input SandboxListInput) (*SandboxListResult, error) {
@@ -169,13 +148,11 @@ func (s *SandboxService) ListPaginated(input SandboxListInput) (*SandboxListResu
 		return nil, err
 	}
 
-	sshEntries := s.EnrichMetadata(sandboxes)
 	return &SandboxListResult{
-		Sandboxes:  sandboxes,
-		SSHEntries: sshEntries,
-		Total:      total,
-		Limit:      input.Limit,
-		Offset:     input.Offset,
+		Sandboxes: sandboxes,
+		Total:     total,
+		Limit:     input.Limit,
+		Offset:    input.Offset,
 	}, nil
 }
 
@@ -238,10 +215,6 @@ func (s *SandboxService) UpdateSandbox(input UpdateSandboxInput) (*models.Sandbo
 		ResourceID:   &sandbox.ID,
 		Details:      details,
 	})
-
-	enriched := []models.Sandbox{*sandbox}
-	s.EnrichMetadata(enriched)
-	*sandbox = enriched[0]
 
 	return sandbox, nil
 }
@@ -373,7 +346,6 @@ func (s *SandboxService) Create(ctx context.Context, input CreateSandboxInput) (
 		go s.executor.RunPostStart(context.Background(), container.ID, resolved.PostStart)
 	}
 
-	fieldsJSON, _ := json.Marshal(input.Metadata)
 	displayName := ""
 	if input.DisplayName != nil {
 		displayName = *input.DisplayName
@@ -392,7 +364,7 @@ func (s *SandboxService) Create(ctx context.Context, input CreateSandboxInput) (
 		URL:           nil,
 		Port:          container.Port,
 		ClientIP:      input.ClientIP,
-		Metadata:      datatypes.JSON(fieldsJSON),
+		Metadata:      registry.ValuesToJSONMap(input.Metadata),
 		ExpiresAt:     expiresAt,
 	}
 	if container.URL != "" {
@@ -423,10 +395,6 @@ func (s *SandboxService) Create(ctx context.Context, input CreateSandboxInput) (
 			"actor":   sandboxActorType(sandbox),
 		},
 	})
-
-	enriched := []models.Sandbox{*sandbox}
-	s.EnrichMetadata(enriched)
-	*sandbox = enriched[0]
 
 	return sandbox, nil
 }
@@ -544,7 +512,7 @@ type CreateSnapshotInput struct {
 	IsPublic    bool
 	ClientIP    string
 	UserID      *uuid.UUID
-	Metadata    json.RawMessage
+	Metadata    map[string]string
 	AuditActor  AuditActor
 }
 
@@ -1014,11 +982,13 @@ func (s *SandboxService) ResolveSSHEntry(imageID uuid.UUID) *registry.SSHEntry {
 	return entry.SSH
 }
 
-func (s *SandboxService) EnrichMetadata(sandboxes []models.Sandbox) map[uuid.UUID]*registry.SSHEntry {
-	type cachedEntry struct {
-		metadata []registry.MetadataItem
-		ssh      *registry.SSHEntry
-	}
+type SandboxEnrichment struct {
+	SSH      *registry.SSHEntry
+	Metadata *registry.MetadataSchema
+}
+
+func (s *SandboxService) EnrichMetadata(sandboxes []models.Sandbox) map[uuid.UUID]SandboxEnrichment {
+	out := make(map[uuid.UUID]SandboxEnrichment, len(sandboxes))
 
 	seen := make(map[uuid.UUID]struct{})
 	var imageIDs []uuid.UUID
@@ -1029,86 +999,61 @@ func (s *SandboxService) EnrichMetadata(sandboxes []models.Sandbox) map[uuid.UUI
 		}
 	}
 
-	sshEntries := make(map[uuid.UUID]*registry.SSHEntry, len(imageIDs))
+	type imageCache struct {
+		registryName string
+		values       map[string]string
+		ssh          *registry.SSHEntry
+	}
+	cache := make(map[uuid.UUID]imageCache, len(imageIDs))
 
 	images, err := s.images.FindByIDs(imageIDs)
 	if err != nil {
 		slog.Warn("enrich sandbox: failed to batch-load images", "error", err)
-		return sshEntries
+		return out
 	}
-	imageMap := make(map[uuid.UUID]*models.Image, len(images))
 	for i := range images {
-		imageMap[images[i].ID] = &images[i]
+		img := &images[i]
+		c := imageCache{
+			registryName: img.RegistryName(),
+			values:       registry.ValuesFromJSONMap(img.Metadata),
+		}
+		if entry := s.resolver.ResolveEntry(c.registryName); entry != nil {
+			c.ssh = entry.SSH
+		}
+		cache[img.ID] = c
 	}
 
-	cache := make(map[uuid.UUID]*cachedEntry, len(imageIDs))
-	for _, id := range imageIDs {
-		img, ok := imageMap[id]
+	for i := range sandboxes {
+		sb := &sandboxes[i]
+		c, ok := cache[sb.ImageID]
 		if !ok {
-			slog.Warn("enrich sandbox: image not found", "image_id", id)
-			cache[id] = nil
 			continue
 		}
-		regEntry := s.resolver.ResolveEntry(img.RegistryName())
-		if regEntry != nil {
-			meta := mergeRegistryAndDB(regEntry.Metadata, img.Metadata)
-			cache[id] = &cachedEntry{metadata: meta, ssh: regEntry.SSH}
-			sshEntries[id] = regEntry.SSH
-		} else {
-			cache[id] = nil
+		values := registry.MergeValues(c.values, registry.ValuesFromJSONMap(sb.Metadata))
+		tctx := registry.TemplateContext{
+			Hostname:      registry.HostnameFromURL(sb.GetURL()),
+			URL:           sb.GetURL(),
+			ContainerID:   sb.ContainerID,
+			ContainerName: sb.ContainerName,
+			SandboxID:     sb.ID.String(),
+			Status:        string(sb.Status),
+			ClientIP:      sb.ClientIP,
 		}
-	}
-
-	for idx := range sandboxes {
-		sb := &sandboxes[idx]
-		entry := cache[sb.ImageID]
-		if entry == nil || len(entry.metadata) == 0 {
+		schema, err := s.resolver.RenderMetadata(c.registryName, values, tctx)
+		if err != nil {
+			slog.Error("metadata render failed",
+				"component", "registry",
+				"sandbox_id", sb.ID,
+				"image_id", sb.ImageID,
+				"registry_match", c.registryName,
+				"error", err)
+			out[sb.ID] = SandboxEnrichment{SSH: c.ssh}
 			continue
 		}
-
-		var values map[string]string
-		if len(sb.Metadata) > 0 {
-			_ = json.Unmarshal(sb.Metadata, &values)
-		}
-		enriched := make([]registry.MetadataItem, len(entry.metadata))
-		copy(enriched, entry.metadata)
-		for j := range enriched {
-			if v, exists := values[enriched[j].Key]; exists {
-				enriched[j].Value = v
-			}
-		}
-		data, _ := json.Marshal(enriched)
-		sb.Metadata = datatypes.JSON(data)
+		out[sb.ID] = SandboxEnrichment{SSH: c.ssh, Metadata: schema}
 	}
 
-	return sshEntries
-}
-
-func mergeRegistryAndDB(reg []registry.MetadataItem, dbJSON datatypes.JSON) []registry.MetadataItem {
-	var dbItems []registry.MetadataItem
-	if len(dbJSON) > 0 {
-		_ = json.Unmarshal(dbJSON, &dbItems)
-	}
-	dbMap := make(map[string]registry.MetadataItem)
-	for _, item := range dbItems {
-		dbMap[item.Key] = item
-	}
-	var merged []registry.MetadataItem
-	for _, item := range reg {
-		if dbItem, ok := dbMap[item.Key]; ok {
-			if dbItem.Value != "" {
-				item.Value = dbItem.Value
-			}
-			delete(dbMap, item.Key)
-		}
-		merged = append(merged, item)
-	}
-	for _, item := range dbItems {
-		if _, ok := dbMap[item.Key]; ok {
-			merged = append(merged, item)
-		}
-	}
-	return merged
+	return out
 }
 
 func splitImageRef(ref string) (string, string) {

--- a/api/registry.yml
+++ b/api/registry.yml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=./internal/registry/schema/registry.schema.json
 images:
   - match: "dockware/*"
     ssh:
@@ -6,43 +7,75 @@ images:
       password: "dockware"
     internal_port: 80
     metadata:
-      - key: "admin_user"
-        label: "Admin Username"
-        type: "field"
-        value: "admin"
-        input: "text"
-        required: true
-        condition: "ready"
-        icon: "user"
-      - key: "admin_password"
-        label: "Admin Password"
-        type: "field"
-        value: "shopware"
-        input: "password"
-        required: true
-        condition: "ready"
-        icon: "lock"
-      - key: "app_env"
-        label: "App Env"
-        type: "field"
-        value: "prod"
-        input: "text"
-        required: true
-        icon: "file-box"
-      - key: "open_admin"
-        label: "Admin"
-        type: "action"
-        value: "{{.URL}}/admin"
-        variant: "default"
-        condition: "ready"
-        icon: "shield"
-      - key: "open_storefront"
-        label: "Storefront"
-        type: "action"
-        value: "{{.URL}}"
-        variant: "outline"
-        condition: "ready"
-        icon: "store"
+      groups:
+        - key: credentials
+          label: Zugangsdaten
+          description: Login für das Shopware-Admin-Panel
+        - key: config
+          label: Konfiguration
+      items:
+        - key: admin_user
+          label: Admin Username
+          type: field
+          icon: user
+          group: credentials
+          visibility:
+            contexts: [image.create, image.edit, sandbox.create, sandbox.card, sandbox.details]
+          field:
+            input: text
+            default: admin
+            required: true
+
+        - key: admin_password
+          label: Admin Password
+          type: field
+          icon: lock
+          group: credentials
+          visibility:
+            contexts: [image.create, image.edit, sandbox.create, sandbox.card, sandbox.details]
+          field:
+            input: password
+            default: shopware
+            required: true
+            help_text: Wird für den Login ins Shopware-Admin-Panel verwendet.
+
+        - key: app_env
+          label: App Environment
+          type: field
+          icon: file-box
+          group: config
+          visibility:
+            contexts: [image.create, image.edit, sandbox.create, sandbox.details]
+          field:
+            input: select
+            default: prod
+            required: true
+            help_text: Steuert Symfony-Environment und Fehler-Verbosity.
+            options:
+              - { value: prod, label: Production }
+              - { value: dev,  label: Development }
+
+        - key: open_admin
+          label: Admin
+          type: action
+          icon: shield
+          visibility:
+            contexts: [sandbox.card, sandbox.details]
+          action:
+            url: "{{.URL}}/admin"
+            variant: default
+            target: _blank
+
+        - key: open_storefront
+          label: Storefront
+          type: action
+          icon: store
+          visibility:
+            contexts: [sandbox.card, sandbox.details]
+          action:
+            url: "{{.URL}}"
+            variant: outline
+            target: _blank
     env:
       TRUSTED_PROXIES: "{{.TrustedProxies}}"
       SHOP_DOMAIN: "{{.Hostname}}"

--- a/web/src/api/images.api.ts
+++ b/web/src/api/images.api.ts
@@ -3,7 +3,7 @@ import { apiClient } from './client'
 import type {
   CreateImageRequest,
   Image,
-  MetadataItem,
+  MetadataSchema,
   PaginatedResponse,
   PaginationParams,
   PendingImage,
@@ -50,10 +50,14 @@ export const imagesApi = {
     await apiClient.delete(`/api/images/${id}`)
   },
 
-  async lookupRegistry(imageName: string): Promise<MetadataItem[]> {
-    const { data } = await apiClient.get<MetadataItem[]>('/api/registry', {
-      params: { name: imageName },
-    })
-    return data
+  async lookupRegistry(imageName: string): Promise<MetadataSchema | null> {
+    try {
+      const { data } = await apiClient.get<MetadataSchema>('/api/registry', {
+        params: { name: imageName },
+      })
+      return data
+    } catch {
+      return null
+    }
   },
 }

--- a/web/src/components/explore/PresetCard.vue
+++ b/web/src/components/explore/PresetCard.vue
@@ -2,6 +2,8 @@
 import { Package } from 'lucide-vue-next'
 import { computed } from 'vue'
 
+import MetadataActionRenderer from '@/components/metadata/MetadataActionRenderer.vue'
+import MetadataSection from '@/components/metadata/MetadataSection.vue'
 import {
   Card,
   CardContent,
@@ -11,24 +13,32 @@ import {
   CardTitle,
 } from '@/components/ui/card'
 import { resolveAssetUrl } from '@/utils/formatters'
-import { resolveIcon } from '@/utils/icons'
+import { extractFieldValues, itemsForContext } from '@/utils/metadata'
 
 import ActionButton from './ActionButton.vue'
 
 import type { CardAction } from './ActionButton.vue'
-import type { MetadataGroup } from './SandboxCard.vue'
-import type { Image } from '@/types'
+import type { ActionItem, Image } from '@/types'
 
 const props = defineProps<{
   image: Image
-  actions: CardAction[]
-  metadata?: MetadataGroup[]
+  extraActions?: CardAction[]
 }>()
 
 const thumbnailSrc = computed(() => resolveAssetUrl(props.image.thumbnailUrl))
+const values = computed(() => extractFieldValues(props.image.metadata))
+const schemaActions = computed(() =>
+  itemsForContext(props.image.metadata, 'image.card').filter(
+    (i): i is ActionItem => i.type === 'action',
+  ),
+)
 
-const primaryActions = computed(() => props.actions.filter((a) => a.variant !== 'destructive'))
-const destructiveActions = computed(() => props.actions.filter((a) => a.variant === 'destructive'))
+const primaryExtras = computed(() =>
+  (props.extraActions ?? []).filter((a) => a.variant !== 'destructive'),
+)
+const destructiveExtras = computed(() =>
+  (props.extraActions ?? []).filter((a) => a.variant === 'destructive'),
+)
 </script>
 
 <template>
@@ -53,39 +63,27 @@ const destructiveActions = computed(() => props.actions.filter((a) => a.variant 
         {{ image.description }}
       </CardDescription>
     </CardHeader>
-    <CardContent v-if="metadata?.length" class="space-y-3 pt-0">
-      <div
-        v-for="group in metadata"
-        :key="group.title"
-        class="bg-muted/50 space-y-1.5 rounded-md border px-3 py-2"
-      >
-        <p class="text-muted-foreground/70 text-[11px] font-medium tracking-wider uppercase">
-          {{ group.title }}
-        </p>
-        <div
-          v-for="field in group.fields"
-          :key="field.label"
-          class="flex items-center justify-between gap-2 text-xs"
-        >
-          <span class="text-muted-foreground flex items-center gap-1">
-            <component :is="resolveIcon(field.icon)" v-if="field.icon" class="h-3 w-3" />
-            {{ field.label }}
-          </span>
-          <span class="font-mono text-[11px]">{{ field.value }}</span>
-        </div>
-      </div>
+    <CardContent class="space-y-3 pt-0">
+      <MetadataSection
+        :metadata="image.metadata"
+        context="image.card"
+        :model-value="values"
+        view="card"
+        hide-actions
+      />
     </CardContent>
     <CardFooter class="mt-auto flex items-center gap-2">
       <div class="flex min-w-0 flex-1 gap-2 [&>*]:flex-1">
+        <MetadataActionRenderer v-for="item in schemaActions" :key="item.key" :item="item" />
         <ActionButton
-          v-for="action in primaryActions"
+          v-for="action in primaryExtras"
           :key="action.label"
           :action="action"
           full-width
         />
       </div>
       <ActionButton
-        v-for="action in destructiveActions"
+        v-for="action in destructiveExtras"
         :key="action.label"
         :action="action"
         class="shrink-0"

--- a/web/src/components/explore/PresetGrid.vue
+++ b/web/src/components/explore/PresetGrid.vue
@@ -4,13 +4,11 @@ import EmptyState from '@/components/shared/EmptyState.vue'
 import PresetCard from './PresetCard.vue'
 
 import type { CardAction } from './ActionButton.vue'
-import type { MetadataGroup } from './SandboxCard.vue'
 import type { Image } from '@/types'
 
 defineProps<{
   images: Image[]
-  getActions: (image: Image) => CardAction[]
-  getMetadata?: (image: Image) => MetadataGroup[]
+  getExtraActions?: (image: Image) => CardAction[]
 }>()
 </script>
 
@@ -20,8 +18,7 @@ defineProps<{
       v-for="image in images"
       :key="image.id"
       :image="image"
-      :actions="getActions(image)"
-      :metadata="getMetadata?.(image)"
+      :extra-actions="getExtraActions?.(image)"
     />
   </div>
   <EmptyState

--- a/web/src/components/explore/SandboxCard.vue
+++ b/web/src/components/explore/SandboxCard.vue
@@ -1,61 +1,46 @@
 <script setup lang="ts">
-import { Check, Copy, Eye, EyeOff, Package } from 'lucide-vue-next'
-import { computed, ref } from 'vue'
+import { Package } from 'lucide-vue-next'
+import { computed } from 'vue'
 
+import MetadataActionRenderer from '@/components/metadata/MetadataActionRenderer.vue'
+import MetadataSection from '@/components/metadata/MetadataSection.vue'
 import TtlChip from '@/components/sandboxes/TtlChip.vue'
 import StatusBadge from '@/components/shared/StatusBadge.vue'
 import { Card, CardContent, CardFooter, CardHeader, CardTitle } from '@/components/ui/card'
-import { Skeleton } from '@/components/ui/skeleton'
-import { resolveIcon } from '@/utils/icons'
+import { extractFieldValues, itemsForContext } from '@/utils/metadata'
 
 import ActionButton from './ActionButton.vue'
 
 import type { CardAction } from './ActionButton.vue'
-import type { Sandbox } from '@/types'
-
-export interface MetadataField {
-  label: string
-  value: string
-  secret?: boolean
-  icon?: string
-  loading?: boolean
-}
-
-export interface MetadataGroup {
-  title: string
-  fields: MetadataField[]
-}
+import type { ActionItem, MetadataContext, Sandbox } from '@/types'
 
 const props = defineProps<{
   sandbox: Sandbox
   title: string
   thumbnailUrl?: string
-  actions?: CardAction[]
-  metadata?: MetadataGroup[]
+  extraActions?: CardAction[]
   stateReason?: string
+  context?: MetadataContext
 }>()
 
-const primaryActions = computed(() =>
-  (props.actions ?? []).filter((a) => a.variant !== 'destructive'),
-)
-const destructiveActions = computed(() =>
-  (props.actions ?? []).filter((a) => a.variant === 'destructive'),
+const ctx = computed<MetadataContext>(() => props.context ?? 'sandbox.card')
+const values = computed(() => extractFieldValues(props.sandbox.metadata))
+const schemaActions = computed(() =>
+  itemsForContext(props.sandbox.metadata, ctx.value).filter(
+    (i): i is ActionItem => i.type === 'action',
+  ),
 )
 
-const copiedKey = ref<string>()
-const revealedKeys = ref<Set<string>>(new Set())
-
-async function copyToClipboard(field: MetadataField) {
-  await navigator.clipboard.writeText(field.value)
-  copiedKey.value = field.label
-  setTimeout(() => {
-    copiedKey.value = undefined
-  }, 1500)
-}
+const destructiveExtras = computed(() =>
+  (props.extraActions ?? []).filter((a) => a.variant === 'destructive'),
+)
+const primaryExtras = computed(() =>
+  (props.extraActions ?? []).filter((a) => a.variant !== 'destructive'),
+)
 </script>
 
 <template>
-  <Card class="flex h-[460px] flex-col overflow-hidden pt-0">
+  <Card class="flex h-full flex-col overflow-hidden pt-0">
     <div class="bg-muted relative flex h-36 shrink-0 items-center justify-center">
       <img
         v-if="thumbnailUrl"
@@ -79,65 +64,34 @@ async function copyToClipboard(field: MetadataField) {
         :expires-at="sandbox.expiresAt"
         :created-at="sandbox.createdAt"
       />
-      <div
-        v-for="group in metadata"
-        :key="group.title"
-        class="bg-muted/50 space-y-1.5 rounded-md border px-3 py-2"
-      >
-        <p class="text-muted-foreground/70 text-[11px] font-medium tracking-wider uppercase">
-          {{ group.title }}
-        </p>
-        <div
-          v-for="field in group.fields"
-          :key="field.label"
-          class="flex items-center justify-between gap-2 text-xs"
-        >
-          <span class="text-muted-foreground flex items-center gap-1">
-            <component :is="resolveIcon(field.icon)" v-if="field.icon" class="h-3 w-3" />
-            {{ field.label }}
-          </span>
-          <div class="flex items-center gap-1">
-            <template v-if="field.loading">
-              <Skeleton class="h-3 w-16 rounded" />
-            </template>
-            <template v-else>
-              <span class="font-mono text-[11px]">
-                {{ field.secret && !revealedKeys.has(field.label) ? '••••••••' : field.value }}
-              </span>
-              <button
-                v-if="field.secret"
-                class="text-muted-foreground hover:text-foreground inline-flex h-5 w-5 items-center justify-center rounded transition-colors"
-                @click="
-                  revealedKeys.has(field.label)
-                    ? revealedKeys.delete(field.label)
-                    : revealedKeys.add(field.label)
-                "
-              >
-                <EyeOff v-if="revealedKeys.has(field.label)" class="h-3 w-3" />
-                <Eye v-else class="h-3 w-3" />
-              </button>
-              <button
-                class="text-muted-foreground hover:text-foreground inline-flex h-5 w-5 items-center justify-center rounded transition-colors"
-                @click="copyToClipboard(field)"
-              >
-                <Check v-if="copiedKey === field.label" class="h-3 w-3 text-green-500" />
-                <Copy v-else class="h-3 w-3" />
-              </button>
-            </template>
-          </div>
-        </div>
-      </div>
+      <MetadataSection
+        :metadata="sandbox.metadata"
+        :context="ctx"
+        :model-value="values"
+        view="card"
+        hide-actions
+      />
     </CardContent>
-    <CardFooter v-if="actions?.length" class="sandbox-actions flex items-center gap-2">
+    <CardFooter
+      v-if="schemaActions.length || extraActions?.length"
+      class="sandbox-actions flex items-center gap-2"
+    >
+      <MetadataActionRenderer
+        v-for="item in schemaActions"
+        :key="item.key"
+        :item="item"
+        :disabled="sandbox.status !== 'running'"
+        class="min-w-0 flex-1"
+      />
       <ActionButton
-        v-for="action in primaryActions"
+        v-for="action in primaryExtras"
         :key="action.label"
         :action="action"
         :full-width="action.size !== 'icon'"
         :class="action.size === 'icon' ? 'shrink-0' : 'min-w-0 flex-1'"
       />
       <ActionButton
-        v-for="action in destructiveActions"
+        v-for="action in destructiveExtras"
         :key="action.label"
         :action="action"
         class="shrink-0"

--- a/web/src/components/metadata/MetadataActionRenderer.vue
+++ b/web/src/components/metadata/MetadataActionRenderer.vue
@@ -1,0 +1,81 @@
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog'
+import { Button } from '@/components/ui/button'
+
+import type { ActionItem } from '@/types'
+
+const props = defineProps<{
+  item: ActionItem
+  disabled?: boolean
+}>()
+
+const variant = computed(() => props.item.action.variant ?? 'default')
+const size = computed(() => (props.item.action.size === 'icon' ? 'icon' : 'default'))
+const target = computed(() => props.item.action.target ?? '_blank')
+const isDestructive = computed(() => variant.value === 'destructive')
+
+const confirmOpen = ref(false)
+
+function proceed() {
+  const { url } = props.item.action
+  if (target.value === '_self') {
+    window.location.href = url
+  } else {
+    window.open(url, '_blank', 'noopener,noreferrer')
+  }
+  confirmOpen.value = false
+}
+
+function onClick(e: MouseEvent) {
+  if (isDestructive.value) {
+    e.preventDefault()
+    confirmOpen.value = true
+  }
+}
+</script>
+
+<template>
+  <template v-if="isDestructive">
+    <Button type="button" :variant="variant" :size="size" :disabled="disabled" @click="onClick">
+      {{ item.label }}
+    </Button>
+    <AlertDialog v-model:open="confirmOpen">
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>{{ item.label }}</AlertDialogTitle>
+          <AlertDialogDescription>
+            {{ item.action.confirm }}
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>Abbrechen</AlertDialogCancel>
+          <AlertDialogAction @click="proceed">Fortfahren</AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  </template>
+
+  <Button
+    v-else
+    as="a"
+    :href="item.action.url"
+    :target="target"
+    :rel="target === '_blank' ? 'noopener noreferrer' : undefined"
+    :variant="variant"
+    :size="size"
+    :disabled="disabled"
+  >
+    {{ item.label }}
+  </Button>
+</template>

--- a/web/src/components/metadata/MetadataDisplayRenderer.vue
+++ b/web/src/components/metadata/MetadataDisplayRenderer.vue
@@ -1,0 +1,136 @@
+<script setup lang="ts">
+import { Check, Copy, Eye, EyeOff } from 'lucide-vue-next'
+import { computed, ref } from 'vue'
+import { toast } from 'vue-sonner'
+
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { resolveIcon } from '@/utils/icons'
+import { maskSecret } from '@/utils/metadata'
+
+import type { DisplayItem } from '@/types'
+
+const props = defineProps<{
+  item: DisplayItem
+  compact?: boolean
+}>()
+
+const revealed = ref(false)
+const justCopied = ref(false)
+
+const isSecret = computed(() => props.item.display.format === 'password')
+const renderedValue = computed(() => {
+  if (isSecret.value && !revealed.value) return maskSecret(props.item.display.value)
+  return props.item.display.value
+})
+
+async function copy() {
+  try {
+    await navigator.clipboard.writeText(props.item.display.value)
+    justCopied.value = true
+    setTimeout(() => (justCopied.value = false), 1500)
+  } catch {
+    toast.error('Kopieren fehlgeschlagen')
+  }
+}
+</script>
+
+<template>
+  <div v-if="compact" class="flex items-center justify-between gap-2 text-xs">
+    <span class="text-muted-foreground flex items-center gap-1">
+      <component :is="resolveIcon(item.icon)" v-if="item.icon" class="h-3 w-3" />
+      {{ item.label }}
+    </span>
+    <div class="flex items-center gap-1">
+      <span class="font-mono text-[11px] break-all">{{ renderedValue }}</span>
+      <Button
+        v-if="isSecret"
+        type="button"
+        variant="ghost"
+        size="icon"
+        class="h-5 w-5"
+        :aria-label="revealed ? 'Wert verbergen' : 'Wert anzeigen'"
+        :aria-pressed="revealed"
+        @click="revealed = !revealed"
+      >
+        <EyeOff v-if="revealed" class="h-3 w-3" />
+        <Eye v-else class="h-3 w-3" />
+      </Button>
+      <Button
+        v-if="item.display.copyable"
+        type="button"
+        variant="ghost"
+        size="icon"
+        class="h-5 w-5"
+        aria-label="Kopieren"
+        @click="copy"
+      >
+        <Check v-if="justCopied" class="h-3 w-3 text-emerald-500" />
+        <Copy v-else class="h-3 w-3" />
+      </Button>
+    </div>
+  </div>
+
+  <div v-else class="flex items-start gap-2">
+    <div class="min-w-0 flex-1">
+      <p class="text-muted-foreground text-xs">{{ item.label }}</p>
+
+      <Badge v-if="item.display.format === 'badge'" variant="secondary" class="mt-1">
+        {{ renderedValue }}
+      </Badge>
+
+      <a
+        v-else-if="item.display.format === 'link'"
+        :href="item.display.value"
+        target="_blank"
+        rel="noopener noreferrer"
+        class="text-primary text-sm break-all hover:underline"
+      >
+        {{ renderedValue }}
+      </a>
+
+      <code
+        v-else-if="item.display.format === 'code'"
+        class="bg-muted mt-1 block rounded px-2 py-1 font-mono text-sm break-all"
+      >
+        {{ renderedValue }}
+      </code>
+
+      <p
+        v-else
+        class="text-sm break-words"
+        :class="isSecret && !revealed ? 'font-mono tracking-widest' : ''"
+      >
+        {{ renderedValue }}
+      </p>
+    </div>
+
+    <div class="flex shrink-0 items-center gap-1">
+      <Button
+        v-if="isSecret"
+        type="button"
+        variant="ghost"
+        size="icon"
+        class="h-7 w-7"
+        :aria-label="revealed ? 'Wert verbergen' : 'Wert anzeigen'"
+        :aria-pressed="revealed"
+        @click="revealed = !revealed"
+      >
+        <EyeOff v-if="revealed" class="h-4 w-4" />
+        <Eye v-else class="h-4 w-4" />
+      </Button>
+      <Button
+        v-if="item.display.copyable"
+        type="button"
+        variant="ghost"
+        size="icon"
+        class="h-7 w-7"
+        aria-label="Kopieren"
+        @click="copy"
+      >
+        <Check v-if="justCopied" class="h-4 w-4 text-emerald-500" />
+        <Copy v-else class="h-4 w-4" />
+      </Button>
+    </div>
+  </div>
+</template>

--- a/web/src/components/metadata/MetadataEditor.vue
+++ b/web/src/components/metadata/MetadataEditor.vue
@@ -1,0 +1,66 @@
+<script setup lang="ts">
+import { Plus } from 'lucide-vue-next'
+import { computed } from 'vue'
+
+import MetadataItemEditor from '@/components/metadata/MetadataItemEditor.vue'
+import { Button } from '@/components/ui/button'
+
+import type { MetadataItem, MetadataSchema } from '@/types'
+
+const props = defineProps<{
+  modelValue: MetadataItem[]
+  registrySchema?: MetadataSchema | null
+  disabled?: boolean
+}>()
+
+const emit = defineEmits<{
+  'update:modelValue': [MetadataItem[]]
+}>()
+
+const items = computed(() => props.modelValue ?? [])
+const lockedKeys = computed(() => new Set((props.registrySchema?.items ?? []).map((it) => it.key)))
+
+function update(index: number, item: MetadataItem) {
+  const next = [...items.value]
+  next[index] = item
+  emit('update:modelValue', next)
+}
+
+function remove(index: number) {
+  const next = [...items.value]
+  next.splice(index, 1)
+  emit('update:modelValue', next)
+}
+
+function add() {
+  emit('update:modelValue', [
+    ...items.value,
+    {
+      key: '',
+      label: '',
+      type: 'action',
+      action: { url: '', target: '_blank' },
+      visibility: { contexts: ['sandbox.card', 'sandbox.details'] },
+    },
+  ])
+}
+</script>
+
+<template>
+  <div class="space-y-3">
+    <MetadataItemEditor
+      v-for="(item, idx) in items"
+      :key="idx"
+      :model-value="item"
+      :index="idx"
+      :disabled="disabled"
+      :locked="lockedKeys.has(item.key)"
+      @update:model-value="(v) => update(idx, v)"
+      @remove="remove(idx)"
+    />
+    <Button type="button" variant="outline" size="sm" :disabled="disabled" @click="add">
+      <Plus class="mr-1 h-4 w-4" />
+      Item hinzufügen
+    </Button>
+  </div>
+</template>

--- a/web/src/components/metadata/MetadataFieldRenderer.vue
+++ b/web/src/components/metadata/MetadataFieldRenderer.vue
@@ -1,0 +1,203 @@
+<script setup lang="ts">
+import { Check, Eye, EyeOff } from 'lucide-vue-next'
+import { computed, ref } from 'vue'
+
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import { Switch } from '@/components/ui/switch'
+import { Textarea } from '@/components/ui/textarea'
+
+import type { FieldItem } from '@/types'
+
+const props = defineProps<{
+  item: FieldItem
+  modelValue: string
+  disabled?: boolean
+  error?: string
+}>()
+
+const emit = defineEmits<{
+  'update:modelValue': [value: string]
+}>()
+
+const helpId = computed(() => `field-help-${props.item.key}`)
+const showSecret = ref(false)
+
+const stringValue = computed<string>({
+  get: () => props.modelValue ?? '',
+  set: (v) => emit('update:modelValue', v ?? ''),
+})
+
+const toggleValue = computed<boolean>({
+  get: () => props.modelValue === 'true',
+  set: (v) => emit('update:modelValue', v ? 'true' : 'false'),
+})
+
+const multiValues = computed<string[]>(() =>
+  props.modelValue
+    ? props.modelValue
+        .split(',')
+        .map((s) => s.trim())
+        .filter(Boolean)
+    : [],
+)
+
+function setMulti(value: string, checked: boolean) {
+  const next = new Set(multiValues.value)
+  if (checked) next.add(value)
+  else next.delete(value)
+  emit('update:modelValue', Array.from(next).join(','))
+}
+
+function isMultiChecked(value: string) {
+  return multiValues.value.includes(value)
+}
+
+const readOnly = computed(() => props.item.field.readOnly === true)
+const effectiveDisabled = computed(() => props.disabled || readOnly.value)
+</script>
+
+<template>
+  <div class="space-y-1.5">
+    <Label :for="item.key" class="flex items-center gap-1">
+      {{ item.label }}
+      <span v-if="item.field.required" class="text-destructive">*</span>
+    </Label>
+
+    <Input
+      v-if="['text', 'email', 'url', 'number'].includes(item.field.input)"
+      :id="item.key"
+      v-model="stringValue"
+      :type="item.field.input === 'number' ? 'number' : item.field.input"
+      :placeholder="item.field.placeholder"
+      :disabled="effectiveDisabled"
+      :aria-describedby="item.field.helpText ? helpId : undefined"
+      :required="item.field.required"
+    />
+
+    <div v-else-if="item.field.input === 'password'" class="relative">
+      <Input
+        :id="item.key"
+        v-model="stringValue"
+        :type="showSecret ? 'text' : 'password'"
+        :placeholder="item.field.placeholder"
+        :disabled="effectiveDisabled"
+        :aria-describedby="item.field.helpText ? helpId : undefined"
+        :required="item.field.required"
+        class="pr-10"
+      />
+      <Button
+        v-if="stringValue"
+        type="button"
+        variant="ghost"
+        size="icon"
+        class="absolute top-1/2 right-1 h-7 w-7 -translate-y-1/2"
+        :aria-label="showSecret ? 'Wert verbergen' : 'Wert anzeigen'"
+        :aria-pressed="showSecret"
+        @click="showSecret = !showSecret"
+      >
+        <EyeOff v-if="showSecret" class="h-4 w-4" />
+        <Eye v-else class="h-4 w-4" />
+      </Button>
+    </div>
+
+    <Textarea
+      v-else-if="item.field.input === 'textarea'"
+      :id="item.key"
+      v-model="stringValue"
+      :placeholder="item.field.placeholder"
+      :disabled="effectiveDisabled"
+      :aria-describedby="item.field.helpText ? helpId : undefined"
+      :required="item.field.required"
+    />
+
+    <div v-else-if="item.field.input === 'toggle'" class="flex h-9 items-center gap-2">
+      <Switch
+        :id="item.key"
+        v-model="toggleValue"
+        :disabled="effectiveDisabled"
+        :aria-describedby="item.field.helpText ? helpId : undefined"
+      />
+      <span class="text-muted-foreground text-sm">
+        {{ toggleValue ? 'Aktiv' : 'Inaktiv' }}
+      </span>
+    </div>
+
+    <Select
+      v-else-if="item.field.input === 'select'"
+      v-model="stringValue"
+      :disabled="effectiveDisabled"
+    >
+      <SelectTrigger
+        :id="item.key"
+        class="w-full"
+        :aria-describedby="item.field.helpText ? helpId : undefined"
+      >
+        <SelectValue :placeholder="item.field.placeholder ?? 'Bitte wählen'" />
+      </SelectTrigger>
+      <SelectContent>
+        <SelectItem v-for="opt in item.field.options ?? []" :key="opt.value" :value="opt.value">
+          {{ opt.label }}
+        </SelectItem>
+      </SelectContent>
+    </Select>
+
+    <Popover v-else-if="item.field.input === 'multiselect'">
+      <PopoverTrigger as-child>
+        <Button
+          :id="item.key"
+          type="button"
+          variant="outline"
+          class="w-full justify-between font-normal"
+          :disabled="effectiveDisabled"
+          :aria-describedby="item.field.helpText ? helpId : undefined"
+        >
+          <span class="truncate">
+            <template v-if="multiValues.length"> {{ multiValues.length }} ausgewählt </template>
+            <template v-else>
+              <span class="text-muted-foreground">
+                {{ item.field.placeholder ?? 'Auswählen' }}
+              </span>
+            </template>
+          </span>
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent class="w-64 p-2">
+        <ul class="space-y-1">
+          <li
+            v-for="opt in item.field.options ?? []"
+            :key="opt.value"
+            class="hover:bg-muted flex cursor-pointer items-center gap-2 rounded px-2 py-1"
+            @click="setMulti(opt.value, !isMultiChecked(opt.value))"
+          >
+            <span
+              class="flex h-4 w-4 items-center justify-center rounded border"
+              :class="
+                isMultiChecked(opt.value)
+                  ? 'bg-primary border-primary text-primary-foreground'
+                  : 'border-input'
+              "
+            >
+              <Check v-if="isMultiChecked(opt.value)" class="h-3 w-3" />
+            </span>
+            <span class="text-sm">{{ opt.label }}</span>
+          </li>
+        </ul>
+      </PopoverContent>
+    </Popover>
+
+    <p v-if="item.field.helpText" :id="helpId" class="text-muted-foreground text-xs">
+      {{ item.field.helpText }}
+    </p>
+    <p v-if="error" class="text-destructive text-xs">{{ error }}</p>
+  </div>
+</template>

--- a/web/src/components/metadata/MetadataItemEditor.vue
+++ b/web/src/components/metadata/MetadataItemEditor.vue
@@ -1,0 +1,387 @@
+<script setup lang="ts">
+import { Trash2 } from 'lucide-vue-next'
+import { computed } from 'vue'
+
+import MetadataActionRenderer from '@/components/metadata/MetadataActionRenderer.vue'
+import MetadataDisplayRenderer from '@/components/metadata/MetadataDisplayRenderer.vue'
+import MetadataFieldRenderer from '@/components/metadata/MetadataFieldRenderer.vue'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import { Switch } from '@/components/ui/switch'
+import { Textarea } from '@/components/ui/textarea'
+
+import type {
+  ActionSpec,
+  ActionTarget,
+  ActionVariant,
+  DisplayFormat,
+  DisplaySpec,
+  FieldInput,
+  FieldSpec,
+  MetadataContext,
+  MetadataItem,
+} from '@/types'
+
+const props = defineProps<{
+  modelValue: MetadataItem
+  index: number
+  disabled?: boolean
+  locked?: boolean
+}>()
+
+const emit = defineEmits<{
+  'update:modelValue': [MetadataItem]
+  remove: []
+}>()
+
+const item = computed(() => props.modelValue)
+
+function patch(partial: Partial<MetadataItem>) {
+  emit('update:modelValue', { ...item.value, ...partial } as MetadataItem)
+}
+
+function patchField(partial: Partial<FieldSpec>) {
+  if (item.value.type !== 'field') return
+  emit('update:modelValue', {
+    ...item.value,
+    field: { ...item.value.field, ...partial },
+  })
+}
+
+function patchAction(partial: Partial<ActionSpec>) {
+  if (item.value.type !== 'action') return
+  emit('update:modelValue', {
+    ...item.value,
+    action: { ...item.value.action, ...partial },
+  })
+}
+
+function patchDisplay(partial: Partial<DisplaySpec>) {
+  if (item.value.type !== 'display') return
+  emit('update:modelValue', {
+    ...item.value,
+    display: { ...item.value.display, ...partial },
+  })
+}
+
+const ALL_CONTEXTS: MetadataContext[] = [
+  'image.create',
+  'image.edit',
+  'image.card',
+  'sandbox.create',
+  'sandbox.card',
+  'sandbox.details',
+]
+const FIELD_INPUTS: FieldInput[] = [
+  'text',
+  'password',
+  'number',
+  'email',
+  'url',
+  'select',
+  'multiselect',
+  'toggle',
+  'textarea',
+]
+const ACTION_VARIANTS: ActionVariant[] = ['default', 'outline', 'destructive']
+const ACTION_TARGETS: ActionTarget[] = ['_blank', '_self']
+const DISPLAY_FORMATS: DisplayFormat[] = ['text', 'code', 'badge', 'link', 'password']
+
+const contexts = computed(() => item.value.visibility?.contexts ?? [])
+function toggleContext(ctx: MetadataContext) {
+  const next = new Set(contexts.value)
+  if (next.has(ctx)) next.delete(ctx)
+  else next.add(ctx)
+  patch({
+    visibility: {
+      ...(item.value.visibility ?? {}),
+      contexts: Array.from(next),
+    },
+  })
+}
+
+function changeType(next: 'field' | 'action' | 'display') {
+  if (next === item.value.type) return
+  const base = {
+    key: item.value.key,
+    label: item.value.label,
+    visibility: item.value.visibility,
+  }
+  if (next === 'field') {
+    emit('update:modelValue', {
+      ...base,
+      type: 'field',
+      field: { input: 'text' },
+    })
+  } else if (next === 'action') {
+    emit('update:modelValue', {
+      ...base,
+      type: 'action',
+      action: { url: '' },
+    })
+  } else {
+    emit('update:modelValue', {
+      ...base,
+      type: 'display',
+      display: { value: '' },
+    })
+  }
+}
+
+function setOptions(raw: string) {
+  if (item.value.type !== 'field') return
+  const lines = raw
+    .split('\n')
+    .map((l) => l.trim())
+    .filter(Boolean)
+  const options = lines.map((line) => {
+    const [value, label] = line.split('=').map((s) => s.trim())
+    return { value, label: label || value }
+  })
+  patchField({ options })
+}
+
+const optionsAsText = computed(() => {
+  if (item.value.type !== 'field' || !item.value.field.options) return ''
+  return item.value.field.options.map((o) => `${o.value}=${o.label}`).join('\n')
+})
+</script>
+
+<template>
+  <div v-if="locked && item.type === 'field'" class="bg-muted/30 rounded-lg border p-4">
+    <MetadataFieldRenderer
+      :item="item"
+      :model-value="item.field.default ?? ''"
+      :disabled="disabled"
+      @update:model-value="(v) => patchField({ default: v })"
+    />
+  </div>
+
+  <div
+    v-else-if="locked && item.type === 'action'"
+    class="bg-muted/30 flex items-center gap-2 rounded-lg border p-4"
+  >
+    <Label class="text-xs font-medium">{{ item.label }}</Label>
+    <MetadataActionRenderer :item="item" disabled />
+  </div>
+
+  <div v-else-if="locked && item.type === 'display'" class="bg-muted/30 rounded-lg border p-4">
+    <MetadataDisplayRenderer :item="item" />
+  </div>
+
+  <div v-else class="bg-muted/30 space-y-3 rounded-lg border p-4">
+    <div class="flex items-center justify-between gap-2">
+      <Label class="text-sm font-medium">Item #{{ index + 1 }}</Label>
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon"
+        class="h-7 w-7"
+        :disabled="disabled"
+        @click="emit('remove')"
+      >
+        <Trash2 class="h-4 w-4" />
+      </Button>
+    </div>
+
+    <div class="grid grid-cols-2 gap-3">
+      <div class="grid gap-1.5">
+        <Label class="text-xs">Typ</Label>
+        <Select
+          :model-value="item.type"
+          :disabled="disabled"
+          @update:model-value="(v) => changeType(v as 'field' | 'action' | 'display')"
+        >
+          <SelectTrigger><SelectValue /></SelectTrigger>
+          <SelectContent>
+            <SelectItem value="field">Feld</SelectItem>
+            <SelectItem value="action">Aktion</SelectItem>
+            <SelectItem value="display">Anzeige</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+      <div class="grid gap-1.5">
+        <Label class="text-xs">Schlüssel</Label>
+        <Input
+          :model-value="item.key"
+          placeholder="my_button"
+          :disabled="disabled"
+          @update:model-value="(v) => patch({ key: String(v) })"
+        />
+      </div>
+      <div class="col-span-2 grid gap-1.5">
+        <Label class="text-xs">Label</Label>
+        <Input
+          :model-value="item.label"
+          placeholder="Sichtbarer Name"
+          :disabled="disabled"
+          @update:model-value="(v) => patch({ label: String(v) })"
+        />
+      </div>
+    </div>
+
+    <div class="grid gap-1.5">
+      <Label class="text-xs">Sichtbarkeit</Label>
+      <div class="flex flex-wrap gap-1.5">
+        <Button
+          v-for="ctx in ALL_CONTEXTS"
+          :key="ctx"
+          type="button"
+          size="sm"
+          :variant="contexts.includes(ctx) ? 'default' : 'outline'"
+          :disabled="disabled"
+          @click="toggleContext(ctx)"
+        >
+          {{ ctx }}
+        </Button>
+      </div>
+    </div>
+
+    <template v-if="item.type === 'field'">
+      <div class="grid grid-cols-2 gap-3">
+        <div class="grid gap-1.5">
+          <Label class="text-xs">Input</Label>
+          <Select
+            :model-value="item.field.input"
+            :disabled="disabled"
+            @update:model-value="(v) => patchField({ input: v as FieldInput })"
+          >
+            <SelectTrigger><SelectValue /></SelectTrigger>
+            <SelectContent>
+              <SelectItem v-for="i in FIELD_INPUTS" :key="i" :value="i">{{ i }}</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+        <div class="grid gap-1.5">
+          <Label class="text-xs">Default</Label>
+          <Input
+            :model-value="item.field.default ?? ''"
+            :disabled="disabled"
+            @update:model-value="(v) => patchField({ default: String(v) })"
+          />
+        </div>
+        <div class="col-span-2 grid gap-1.5">
+          <Label class="text-xs">Hilfetext</Label>
+          <Input
+            :model-value="item.field.helpText ?? ''"
+            :disabled="disabled"
+            @update:model-value="(v) => patchField({ helpText: String(v) || undefined })"
+          />
+        </div>
+        <div class="flex items-center gap-2">
+          <Switch
+            :model-value="!!item.field.required"
+            :disabled="disabled"
+            @update:model-value="(v) => patchField({ required: v })"
+          />
+          <Label class="text-xs">Pflichtfeld</Label>
+        </div>
+        <div
+          v-if="['select', 'multiselect'].includes(item.field.input)"
+          class="col-span-2 grid gap-1.5"
+        >
+          <Label class="text-xs">Optionen (eine pro Zeile, value=label)</Label>
+          <Textarea
+            :model-value="optionsAsText"
+            placeholder="prod=Production"
+            :disabled="disabled"
+            @update:model-value="(v) => setOptions(String(v))"
+          />
+        </div>
+      </div>
+    </template>
+
+    <template v-else-if="item.type === 'action'">
+      <div class="grid gap-3">
+        <div class="grid gap-1.5">
+          <Label class="text-xs">URL (Go-Template)</Label>
+          <Input
+            :model-value="item.action.url"
+            :disabled="disabled"
+            @update:model-value="(v) => patchAction({ url: String(v) })"
+          />
+        </div>
+        <div class="grid grid-cols-2 gap-3">
+          <div class="grid gap-1.5">
+            <Label class="text-xs">Variant</Label>
+            <Select
+              :model-value="item.action.variant ?? 'default'"
+              :disabled="disabled"
+              @update:model-value="(v) => patchAction({ variant: v as ActionVariant })"
+            >
+              <SelectTrigger><SelectValue /></SelectTrigger>
+              <SelectContent>
+                <SelectItem v-for="v in ACTION_VARIANTS" :key="v" :value="v">{{ v }}</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+          <div class="grid gap-1.5">
+            <Label class="text-xs">Target</Label>
+            <Select
+              :model-value="item.action.target ?? '_blank'"
+              :disabled="disabled"
+              @update:model-value="(v) => patchAction({ target: v as ActionTarget })"
+            >
+              <SelectTrigger><SelectValue /></SelectTrigger>
+              <SelectContent>
+                <SelectItem v-for="t in ACTION_TARGETS" :key="t" :value="t">{{ t }}</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+        </div>
+        <div v-if="item.action.variant === 'destructive'" class="grid gap-1.5">
+          <Label class="text-xs">Bestätigung (Pflicht für destructive)</Label>
+          <Input
+            :model-value="item.action.confirm ?? ''"
+            :disabled="disabled"
+            @update:model-value="(v) => patchAction({ confirm: String(v) })"
+          />
+        </div>
+      </div>
+    </template>
+
+    <template v-else-if="item.type === 'display'">
+      <div class="grid gap-3">
+        <div class="grid gap-1.5">
+          <Label class="text-xs">Wert (Go-Template oder Text)</Label>
+          <Textarea
+            :model-value="item.display.value"
+            :disabled="disabled"
+            @update:model-value="(v) => patchDisplay({ value: String(v) })"
+          />
+        </div>
+        <div class="grid grid-cols-2 gap-3">
+          <div class="grid gap-1.5">
+            <Label class="text-xs">Format</Label>
+            <Select
+              :model-value="item.display.format ?? 'text'"
+              :disabled="disabled"
+              @update:model-value="(v) => patchDisplay({ format: v as DisplayFormat })"
+            >
+              <SelectTrigger><SelectValue /></SelectTrigger>
+              <SelectContent>
+                <SelectItem v-for="f in DISPLAY_FORMATS" :key="f" :value="f">{{ f }}</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+          <div class="flex items-center gap-2">
+            <Switch
+              :model-value="!!item.display.copyable"
+              :disabled="disabled"
+              @update:model-value="(v) => patchDisplay({ copyable: v })"
+            />
+            <Label class="text-xs">Kopierbar</Label>
+          </div>
+        </div>
+      </div>
+    </template>
+  </div>
+</template>

--- a/web/src/components/metadata/MetadataSection.vue
+++ b/web/src/components/metadata/MetadataSection.vue
@@ -1,0 +1,128 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+
+import MetadataActionRenderer from '@/components/metadata/MetadataActionRenderer.vue'
+import MetadataDisplayRenderer from '@/components/metadata/MetadataDisplayRenderer.vue'
+import MetadataFieldRenderer from '@/components/metadata/MetadataFieldRenderer.vue'
+import { Label } from '@/components/ui/label'
+import {
+  evaluateDependsOn,
+  fieldAsDisplay,
+  groupItems,
+  isFieldItem,
+  itemsForContext,
+} from '@/utils/metadata'
+
+import type {
+  ActionItem,
+  DisplayItem,
+  FieldItem,
+  MetadataContext,
+  MetadataGroup,
+  MetadataItem,
+} from '@/types'
+
+type View = 'form' | 'card'
+
+const props = defineProps<{
+  metadata: MetadataItem[] | null | undefined
+  context: MetadataContext
+  groups?: MetadataGroup[]
+  modelValue?: Record<string, string>
+  view?: View
+  disabled?: boolean
+  title?: string
+  showHeading?: boolean
+  actionsDisabled?: boolean
+  hideActions?: boolean
+}>()
+
+const emit = defineEmits<{
+  'update:modelValue': [Record<string, string>]
+}>()
+
+const view = computed<View>(() => props.view ?? 'form')
+const values = computed<Record<string, string>>(() => props.modelValue ?? {})
+
+const visible = computed(() => itemsForContext(props.metadata, props.context))
+const fields = computed(() =>
+  visible.value.filter(isFieldItem).filter((i) => evaluateDependsOn(i, values.value)),
+)
+const actions = computed(() => visible.value.filter((i): i is ActionItem => i.type === 'action'))
+const displays = computed(() => visible.value.filter((i): i is DisplayItem => i.type === 'display'))
+
+const fieldLikeItems = computed<Array<FieldItem | DisplayItem>>(() => [
+  ...displays.value,
+  ...fields.value,
+])
+
+const bucketed = computed(() => groupItems(fieldLikeItems.value, props.groups))
+
+function setValue(key: string, value: string) {
+  emit('update:modelValue', { ...values.value, [key]: value })
+}
+
+function asDisplay(item: FieldItem): DisplayItem {
+  return fieldAsDisplay(item, view.value === 'form') as DisplayItem
+}
+</script>
+
+<template>
+  <div v-if="bucketed.length || (!hideActions && actions.length)" class="space-y-4">
+    <div v-if="showHeading" class="flex items-center gap-3">
+      <Label class="text-sm font-medium">{{ title ?? 'Metadaten' }}</Label>
+      <div class="bg-border h-px flex-1" />
+    </div>
+
+    <div
+      v-for="bucket in bucketed"
+      :key="bucket.group?.key ?? '_default'"
+      :class="
+        view === 'card'
+          ? 'bg-muted/50 space-y-2 rounded-md border px-3 py-2'
+          : 'bg-muted/30 space-y-4 rounded-lg border p-4'
+      "
+    >
+      <div
+        v-if="bucket.group"
+        :class="
+          view === 'card'
+            ? 'text-muted-foreground/70 text-[11px] font-medium tracking-wider uppercase'
+            : 'space-y-0.5 border-b pb-2'
+        "
+      >
+        <template v-if="view === 'card'">{{ bucket.group.label }}</template>
+        <template v-else>
+          <p class="text-sm font-medium">{{ bucket.group.label }}</p>
+          <p v-if="bucket.group.description" class="text-muted-foreground text-xs">
+            {{ bucket.group.description }}
+          </p>
+        </template>
+      </div>
+      <div :class="view === 'card' ? '' : 'space-y-4'">
+        <template v-for="item in bucket.items" :key="item.key">
+          <template v-if="isFieldItem(item)">
+            <MetadataFieldRenderer
+              v-if="view === 'form'"
+              :item="item"
+              :model-value="values[item.key] ?? item.field.default ?? ''"
+              :disabled="disabled"
+              @update:model-value="(v) => setValue(item.key, v)"
+            />
+            <MetadataDisplayRenderer v-else :item="asDisplay(item)" compact />
+          </template>
+          <MetadataDisplayRenderer v-else :item="item as DisplayItem" :compact="view === 'card'" />
+        </template>
+      </div>
+    </div>
+
+    <div v-if="!hideActions && actions.length" class="flex flex-wrap gap-2">
+      <MetadataActionRenderer
+        v-for="item in actions"
+        :key="item.key"
+        :item="item"
+        :disabled="actionsDisabled"
+      />
+    </div>
+  </div>
+</template>

--- a/web/src/components/modals/AddImageDialog.vue
+++ b/web/src/components/modals/AddImageDialog.vue
@@ -1,10 +1,10 @@
 <script setup lang="ts">
-import { Loader2, Lock, Plus, Trash2, Upload } from 'lucide-vue-next'
-import { computed, ref, watch } from 'vue'
+import { Loader2, Trash2, Upload } from 'lucide-vue-next'
+import { ref, watch } from 'vue'
 
 import { imagesApi, registrySearchApi } from '@/api'
+import MetadataEditor from '@/components/metadata/MetadataEditor.vue'
 import AutocompleteInput from '@/components/shared/AutocompleteInput.vue'
-import IconPicker from '@/components/shared/IconPicker.vue'
 import { Button } from '@/components/ui/button'
 import {
   Dialog,
@@ -19,15 +19,9 @@ import { Label } from '@/components/ui/label'
 import { Switch } from '@/components/ui/switch'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { Textarea } from '@/components/ui/textarea'
-import {
-  collectMetadata,
-  metadataItemToRow,
-  type MetadataRow,
-  newMetadataRow,
-} from '@/utils/metadata'
 
 import type { Suggestion } from '@/components/shared/AutocompleteInput.vue'
-import type { MetadataItem } from '@/types'
+import type { MetadataItem, MetadataSchema } from '@/types'
 
 const props = defineProps<{
   open: boolean
@@ -64,70 +58,55 @@ const tagSuggestions = ref<Suggestion[]>([])
 const imageSearchLoading = ref(false)
 const tagSearchLoading = ref(false)
 
-const registryMeta = ref<MetadataItem[]>([])
-const fieldRows = ref<MetadataRow[]>([])
-const actionRows = ref<MetadataRow[]>([])
+const metadata = ref<MetadataItem[]>([])
+const registrySchema = ref<MetadataSchema | null>(null)
 
-let lookupTimer: ReturnType<typeof setTimeout> | undefined
 let imageSearchTimer: ReturnType<typeof setTimeout> | undefined
 let tagSearchTimer: ReturnType<typeof setTimeout> | undefined
-
-const registryFields = computed(() =>
-  registryMeta.value.filter((m) => m.type === 'field' || m.type === 'setting'),
-)
-const registryActions = computed(() => registryMeta.value.filter((m) => m.type === 'action'))
+let registryLookupTimer: ReturnType<typeof setTimeout> | undefined
 
 watch(name, (val) => {
-  clearTimeout(lookupTimer)
   clearTimeout(imageSearchTimer)
+  clearTimeout(registryLookupTimer)
   tagSuggestions.value = []
 
-  if (!val) {
-    registryMeta.value = []
+  if (!val || val.length < 2) {
     imageSuggestions.value = []
-    rebuildRows()
+    imageSearchLoading.value = false
+    registrySchema.value = null
+    metadata.value = []
     return
   }
 
-  lookupTimer = setTimeout(async () => {
-    try {
-      registryMeta.value = await imagesApi.lookupRegistry(val)
-    } catch {
-      registryMeta.value = []
-    }
-    rebuildRows()
+  registryLookupTimer = setTimeout(async () => {
+    const schema = await imagesApi.lookupRegistry(val)
+    registrySchema.value = schema
+    metadata.value = [...(schema?.items ?? [])]
   }, 400)
 
-  if (val.length >= 2) {
-    imageSearchLoading.value = true
-    imageSearchTimer = setTimeout(async () => {
-      try {
-        const results = await registrySearchApi.searchImages(val)
-        imageSuggestions.value = results.map((r) => ({
-          value: r.name,
-          label: r.name,
-          description: r.description || undefined,
-        }))
-      } catch {
-        imageSuggestions.value = []
-      } finally {
-        imageSearchLoading.value = false
-      }
-    }, 400)
-  } else {
-    imageSuggestions.value = []
-    imageSearchLoading.value = false
-  }
+  imageSearchLoading.value = true
+  imageSearchTimer = setTimeout(async () => {
+    try {
+      const results = await registrySearchApi.searchImages(val)
+      imageSuggestions.value = results.map((r) => ({
+        value: r.name,
+        label: r.name,
+        description: r.description || undefined,
+      }))
+    } catch {
+      imageSuggestions.value = []
+    } finally {
+      imageSearchLoading.value = false
+    }
+  }, 400)
 })
 
 watch(tag, (val) => {
   clearTimeout(tagSearchTimer)
-
   if (!name.value) {
     tagSuggestions.value = []
     return
   }
-
   tagSearchLoading.value = true
   tagSearchTimer = setTimeout(async () => {
     try {
@@ -147,20 +126,6 @@ watch(tag, (val) => {
   }, 400)
 })
 
-function rebuildRows() {
-  const customFields = fieldRows.value.filter((r) => !r.fromRegistry)
-  const customActions = actionRows.value.filter((r) => !r.fromRegistry)
-
-  fieldRows.value = [
-    ...registryFields.value.map((m) => metadataItemToRow(m, true)),
-    ...customFields,
-  ]
-  actionRows.value = [
-    ...registryActions.value.map((m) => metadataItemToRow(m, true)),
-    ...customActions,
-  ]
-}
-
 function revokeBlobPreview() {
   if (thumbnailPreview.value?.startsWith('blob:')) {
     URL.revokeObjectURL(thumbnailPreview.value)
@@ -177,9 +142,11 @@ function resetState() {
   thumbnailFile.value = null
   thumbnailPreview.value = undefined
   busy.value = false
-  registryMeta.value = []
-  fieldRows.value = []
-  actionRows.value = []
+  metadata.value = []
+  registrySchema.value = null
+  clearTimeout(imageSearchTimer)
+  clearTimeout(tagSearchTimer)
+  clearTimeout(registryLookupTimer)
   imageSuggestions.value = []
   tagSuggestions.value = []
   imageSearchLoading.value = false
@@ -210,27 +177,9 @@ function handleRemoveThumbnail() {
   if (fileInputRef.value) fileInputRef.value.value = ''
 }
 
-function addField() {
-  fieldRows.value.push(newMetadataRow())
-}
-
-function removeField(index: number) {
-  fieldRows.value.splice(index, 1)
-}
-
-function addAction() {
-  actionRows.value.push(newMetadataRow())
-}
-
-function removeAction(index: number) {
-  actionRows.value.splice(index, 1)
-}
-
 function handleSubmit() {
   if (!name.value || !tag.value) return
   busy.value = true
-
-  const metadata = collectMetadata(fieldRows.value, actionRows.value)
 
   emit(
     'submit',
@@ -241,7 +190,7 @@ function handleSubmit() {
       description: description.value,
       isPublic: isPublic.value,
       thumbnailFile: thumbnailFile.value ?? undefined,
-      metadata,
+      metadata: metadata.value,
     },
     (success: boolean) => {
       busy.value = false
@@ -255,12 +204,12 @@ function handleSubmit() {
 
 <template>
   <Dialog :open="open" @update:open="emit('update:open', $event)">
-    <DialogContent class="max-h-[90vh] overflow-y-auto sm:max-w-[540px]">
+    <DialogContent class="max-h-[90vh] overflow-y-auto sm:max-w-160">
       <DialogHeader>
         <DialogTitle>Vorlage hinzufügen</DialogTitle>
-        <DialogDescription
-          >Füge ein neues Docker-Image als Sandbox-Vorlage hinzu.</DialogDescription
-        >
+        <DialogDescription>
+          Füge ein neues Docker-Image als Sandbox-Vorlage hinzu.
+        </DialogDescription>
       </DialogHeader>
       <form @submit.prevent="handleSubmit">
         <Tabs default-value="general" class="mt-2">
@@ -269,7 +218,7 @@ function handleSubmit() {
             <TabsTrigger value="metadata" class="flex-1">Metadaten</TabsTrigger>
           </TabsList>
 
-          <TabsContent value="general" class="mt-4 grid min-h-[380px] gap-4">
+          <TabsContent value="general" class="mt-4 grid min-h-95 gap-4">
             <div class="grid gap-2">
               <Label for="image-name">Image Name</Label>
               <AutocompleteInput
@@ -355,137 +304,8 @@ function handleSubmit() {
             </div>
           </TabsContent>
 
-          <TabsContent value="metadata" class="mt-4 grid min-h-[380px] content-start gap-4">
-            <div class="grid gap-2">
-              <Label>Felder</Label>
-              <div v-for="(row, index) in fieldRows" :key="index" class="space-y-1.5">
-                <div class="flex items-center gap-2">
-                  <div class="relative flex-1">
-                    <Input
-                      v-model="row.label"
-                      placeholder="Label"
-                      :disabled="busy || row.fromRegistry"
-                      :class="{ 'pr-7': row.fromRegistry }"
-                    />
-                    <Lock
-                      v-if="row.fromRegistry"
-                      class="text-muted-foreground absolute top-1/2 right-2 h-3.5 w-3.5 -translate-y-1/2"
-                    />
-                  </div>
-                  <Input v-model="row.value" placeholder="Wert" class="flex-1" :disabled="busy" />
-                  <Button
-                    v-if="!row.fromRegistry"
-                    type="button"
-                    variant="ghost"
-                    size="icon"
-                    :disabled="busy"
-                    @click="removeField(index)"
-                  >
-                    <Trash2 class="h-4 w-4" />
-                  </Button>
-                  <div v-else class="w-9" />
-                </div>
-                <div v-if="!row.fromRegistry" class="flex gap-1.5 pl-0.5">
-                  <IconPicker v-model="row.icon" :disabled="busy" />
-                  <select
-                    v-model="row.show"
-                    class="border-input bg-background h-7 rounded-md border px-1.5 text-[11px]"
-                    :disabled="busy"
-                  >
-                    <option value="sandbox">Sandbox</option>
-                    <option value="template">Template</option>
-                    <option value="both">Beide</option>
-                  </select>
-                  <select
-                    v-model="row.condition"
-                    class="border-input bg-background h-7 rounded-md border px-1.5 text-[11px]"
-                    :disabled="busy"
-                  >
-                    <option value="always">Immer</option>
-                    <option value="ready">Wenn bereit</option>
-                  </select>
-                </div>
-              </div>
-              <Button type="button" variant="outline" size="sm" :disabled="busy" @click="addField">
-                <Plus class="mr-1 h-4 w-4" />
-                Feld hinzufügen
-              </Button>
-            </div>
-
-            <div class="grid gap-2">
-              <Label>Aktionen</Label>
-              <div v-for="(row, index) in actionRows" :key="index" class="space-y-1.5">
-                <div class="flex items-center gap-2">
-                  <div class="relative flex-1">
-                    <Input
-                      v-model="row.label"
-                      placeholder="Label"
-                      :disabled="busy || row.fromRegistry"
-                      :class="{ 'pr-7': row.fromRegistry }"
-                    />
-                    <Lock
-                      v-if="row.fromRegistry"
-                      class="text-muted-foreground absolute top-1/2 right-2 h-3.5 w-3.5 -translate-y-1/2"
-                    />
-                  </div>
-                  <div class="relative flex-1">
-                    <Input
-                      v-model="row.value"
-                      placeholder="https://..."
-                      :disabled="busy || row.fromRegistry"
-                      :class="{ 'pr-7': row.fromRegistry }"
-                    />
-                    <Lock
-                      v-if="row.fromRegistry"
-                      class="text-muted-foreground absolute top-1/2 right-2 h-3.5 w-3.5 -translate-y-1/2"
-                    />
-                  </div>
-                  <Button
-                    v-if="!row.fromRegistry"
-                    type="button"
-                    variant="ghost"
-                    size="icon"
-                    :disabled="busy"
-                    @click="removeAction(index)"
-                  >
-                    <Trash2 class="h-4 w-4" />
-                  </Button>
-                  <div v-else class="w-9" />
-                </div>
-                <div v-if="!row.fromRegistry" class="flex gap-1.5 pl-0.5">
-                  <IconPicker v-model="row.icon" :disabled="busy" />
-                  <select
-                    v-model="row.show"
-                    class="border-input bg-background h-7 rounded-md border px-1.5 text-[11px]"
-                    :disabled="busy"
-                  >
-                    <option value="sandbox">Sandbox</option>
-                    <option value="template">Template</option>
-                    <option value="both">Beide</option>
-                  </select>
-                  <select
-                    v-model="row.condition"
-                    class="border-input bg-background h-7 rounded-md border px-1.5 text-[11px]"
-                    :disabled="busy"
-                  >
-                    <option value="always">Immer</option>
-                    <option value="ready">Wenn bereit</option>
-                  </select>
-                  <select
-                    v-model="row.size"
-                    class="border-input bg-background h-7 rounded-md border px-1.5 text-[11px]"
-                    :disabled="busy"
-                  >
-                    <option value="default">Normal</option>
-                    <option value="icon">Nur Icon</option>
-                  </select>
-                </div>
-              </div>
-              <Button type="button" variant="outline" size="sm" :disabled="busy" @click="addAction">
-                <Plus class="mr-1 h-4 w-4" />
-                Aktion hinzufügen
-              </Button>
-            </div>
+          <TabsContent value="metadata" class="mt-4 min-h-95">
+            <MetadataEditor v-model="metadata" :registry-schema="registrySchema" :disabled="busy" />
           </TabsContent>
         </Tabs>
 

--- a/web/src/components/modals/EditImageDrawer.vue
+++ b/web/src/components/modals/EditImageDrawer.vue
@@ -1,10 +1,10 @@
 <script setup lang="ts">
-import { Loader2, Lock, Plus, Trash2, Upload } from 'lucide-vue-next'
+import { Loader2, Trash2, Upload } from 'lucide-vue-next'
 import { ref, watch } from 'vue'
 import { toast } from 'vue-sonner'
 
 import { imagesApi } from '@/api'
-import IconPicker from '@/components/shared/IconPicker.vue'
+import MetadataEditor from '@/components/metadata/MetadataEditor.vue'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
@@ -18,16 +18,11 @@ import {
 } from '@/components/ui/sheet'
 import { Switch } from '@/components/ui/switch'
 import { Textarea } from '@/components/ui/textarea'
+import { useImagesStore } from '@/stores/images.store'
 import { getApiErrorMessage } from '@/utils/error'
 import { resolveAssetUrl } from '@/utils/formatters'
-import {
-  collectMetadata,
-  metadataItemToRow,
-  type MetadataRow,
-  newMetadataRow,
-} from '@/utils/metadata'
 
-import type { Image, MetadataItem } from '@/types'
+import type { Image, MetadataItem, MetadataSchema } from '@/types'
 
 const props = defineProps<{
   open: boolean
@@ -48,9 +43,9 @@ const removeThumbnail = ref(false)
 const busy = ref(false)
 const fileInputRef = ref<HTMLInputElement | null>(null)
 
-const fieldRows = ref<MetadataRow[]>([])
-const actionRows = ref<MetadataRow[]>([])
-const registryKeys = ref<Set<string>>(new Set())
+const metadata = ref<MetadataItem[]>([])
+const registrySchema = ref<MetadataSchema | null>(null)
+const imagesStore = useImagesStore()
 
 function revokeBlobPreview() {
   if (thumbnailPreview.value?.startsWith('blob:')) {
@@ -73,38 +68,10 @@ watch(
     busy.value = false
     if (fileInputRef.value) fileInputRef.value.value = ''
 
-    const regMeta = await imagesApi
-      .lookupRegistry(props.image.registryRef ?? props.image.name)
-      .catch(() => [] as MetadataItem[])
-
-    const regKeySet = new Set(regMeta.map((m) => m.key))
-    registryKeys.value = regKeySet
-
-    const allMeta = props.image.metadata ?? []
-    const imgValueMap = new Map(allMeta.map((m) => [m.key, m.value]))
-    const customOnly = allMeta.filter((m) => !regKeySet.has(m.key))
-
-    function toRow(m: MetadataItem, fromReg: boolean): MetadataRow {
-      const row = metadataItemToRow(m, fromReg)
-      if (fromReg) {
-        row.value = imgValueMap.get(m.key) ?? m.value ?? ''
-      }
-      return row
-    }
-
-    fieldRows.value = [
-      ...regMeta
-        .filter((m) => m.type === 'field' || m.type === 'setting')
-        .map((m) => toRow(m, true)),
-      ...customOnly
-        .filter((m) => m.type === 'field' || m.type === 'setting')
-        .map((m) => toRow(m, false)),
-    ]
-
-    actionRows.value = [
-      ...regMeta.filter((m) => m.type === 'action').map((m) => toRow(m, true)),
-      ...customOnly.filter((m) => m.type === 'action').map((m) => toRow(m, false)),
-    ]
+    metadata.value = [...(props.image.metadata ?? [])]
+    registrySchema.value = await imagesApi.lookupRegistry(
+      props.image.registryRef ?? props.image.name,
+    )
   },
 )
 
@@ -126,40 +93,25 @@ function handleRemoveThumbnail() {
   if (fileInputRef.value) fileInputRef.value.value = ''
 }
 
-function addField() {
-  fieldRows.value.push(newMetadataRow())
-}
-
-function removeField(index: number) {
-  fieldRows.value.splice(index, 1)
-}
-
-function addAction() {
-  actionRows.value.push(newMetadataRow())
-}
-
-function removeAction(index: number) {
-  actionRows.value.splice(index, 1)
-}
-
 async function handleSubmit() {
   if (!props.image) return
   busy.value = true
   try {
-    const metadata = collectMetadata(fieldRows.value, actionRows.value)
-
-    await imagesApi.update(props.image.id, {
+    let updated = await imagesApi.update(props.image.id, {
       title: title.value || null,
       description: description.value || null,
       isPublic: isPublic.value,
-      metadata,
+      metadata: metadata.value,
     })
 
     if (thumbnailFile.value) {
-      await imagesApi.uploadThumbnail(props.image.id, thumbnailFile.value)
+      updated = await imagesApi.uploadThumbnail(props.image.id, thumbnailFile.value)
     } else if (removeThumbnail.value && props.image.thumbnailUrl) {
       await imagesApi.deleteThumbnail(props.image.id)
+      updated = { ...updated, thumbnailUrl: undefined }
     }
+
+    imagesStore.upsertImage(updated)
 
     toast.success('Vorlage wurde aktualisiert')
     emit('saved')
@@ -239,137 +191,11 @@ async function handleSubmit() {
           <Label for="edit-public">Öffentlich sichtbar</Label>
           <Switch id="edit-public" v-model="isPublic" :disabled="busy" />
         </div>
-
-        <div class="grid gap-2">
-          <Label>Felder</Label>
-          <div v-for="(row, index) in fieldRows" :key="index" class="space-y-1.5">
-            <div class="flex items-center gap-2">
-              <div class="relative flex-1">
-                <Input
-                  v-model="row.label"
-                  placeholder="Label"
-                  :disabled="busy || row.fromRegistry"
-                  :class="{ 'pr-7': row.fromRegistry }"
-                />
-                <Lock
-                  v-if="row.fromRegistry"
-                  class="text-muted-foreground absolute top-1/2 right-2 h-3.5 w-3.5 -translate-y-1/2"
-                />
-              </div>
-              <Input v-model="row.value" placeholder="Wert" class="flex-1" :disabled="busy" />
-              <Button
-                v-if="!row.fromRegistry"
-                type="button"
-                variant="ghost"
-                size="icon"
-                :disabled="busy"
-                @click="removeField(index)"
-              >
-                <Trash2 class="h-4 w-4" />
-              </Button>
-              <div v-else class="w-9" />
-            </div>
-            <div v-if="!row.fromRegistry" class="flex gap-1.5 pl-0.5">
-              <IconPicker v-model="row.icon" :disabled="busy" />
-              <select
-                v-model="row.show"
-                class="border-input bg-background h-7 rounded-md border px-1.5 text-[11px]"
-                :disabled="busy"
-              >
-                <option value="sandbox">Sandbox</option>
-                <option value="template">Template</option>
-                <option value="both">Beide</option>
-              </select>
-              <select
-                v-model="row.condition"
-                class="border-input bg-background h-7 rounded-md border px-1.5 text-[11px]"
-                :disabled="busy"
-              >
-                <option value="always">Immer</option>
-                <option value="ready">Wenn bereit</option>
-              </select>
-            </div>
-          </div>
-          <Button type="button" variant="outline" size="sm" :disabled="busy" @click="addField">
-            <Plus class="mr-1 h-4 w-4" />
-            Feld hinzufügen
-          </Button>
+        <div class="flex items-center gap-3 pt-2">
+          <Label class="text-sm font-medium">Metadaten</Label>
+          <div class="bg-border h-px flex-1" />
         </div>
-
-        <div class="grid gap-2">
-          <Label>Aktionen</Label>
-          <div v-for="(row, index) in actionRows" :key="index" class="space-y-1.5">
-            <div class="flex items-center gap-2">
-              <div class="relative flex-1">
-                <Input
-                  v-model="row.label"
-                  placeholder="Label"
-                  :disabled="busy || row.fromRegistry"
-                  :class="{ 'pr-7': row.fromRegistry }"
-                />
-                <Lock
-                  v-if="row.fromRegistry"
-                  class="text-muted-foreground absolute top-1/2 right-2 h-3.5 w-3.5 -translate-y-1/2"
-                />
-              </div>
-              <div class="relative flex-1">
-                <Input
-                  v-model="row.value"
-                  placeholder="https://..."
-                  :disabled="busy || row.fromRegistry"
-                  :class="{ 'pr-7': row.fromRegistry }"
-                />
-                <Lock
-                  v-if="row.fromRegistry"
-                  class="text-muted-foreground absolute top-1/2 right-2 h-3.5 w-3.5 -translate-y-1/2"
-                />
-              </div>
-              <Button
-                v-if="!row.fromRegistry"
-                type="button"
-                variant="ghost"
-                size="icon"
-                :disabled="busy"
-                @click="removeAction(index)"
-              >
-                <Trash2 class="h-4 w-4" />
-              </Button>
-              <div v-else class="w-9" />
-            </div>
-            <div v-if="!row.fromRegistry" class="flex gap-1.5 pl-0.5">
-              <IconPicker v-model="row.icon" :disabled="busy" />
-              <select
-                v-model="row.show"
-                class="border-input bg-background h-7 rounded-md border px-1.5 text-[11px]"
-                :disabled="busy"
-              >
-                <option value="sandbox">Sandbox</option>
-                <option value="template">Template</option>
-                <option value="both">Beide</option>
-              </select>
-              <select
-                v-model="row.condition"
-                class="border-input bg-background h-7 rounded-md border px-1.5 text-[11px]"
-                :disabled="busy"
-              >
-                <option value="always">Immer</option>
-                <option value="ready">Wenn bereit</option>
-              </select>
-              <select
-                v-model="row.size"
-                class="border-input bg-background h-7 rounded-md border px-1.5 text-[11px]"
-                :disabled="busy"
-              >
-                <option value="default">Normal</option>
-                <option value="icon">Nur Icon</option>
-              </select>
-            </div>
-          </div>
-          <Button type="button" variant="outline" size="sm" :disabled="busy" @click="addAction">
-            <Plus class="mr-1 h-4 w-4" />
-            Aktion hinzufügen
-          </Button>
-        </div>
+        <MetadataEditor v-model="metadata" :registry-schema="registrySchema" :disabled="busy" />
       </form>
       <SheetFooter>
         <Button type="button" variant="outline" :disabled="busy" @click="emit('update:open', false)"

--- a/web/src/components/modals/NewSandboxDialog.vue
+++ b/web/src/components/modals/NewSandboxDialog.vue
@@ -2,6 +2,7 @@
 import { Loader2 } from 'lucide-vue-next'
 import { computed, ref, watch } from 'vue'
 
+import MetadataSection from '@/components/metadata/MetadataSection.vue'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import {
@@ -16,6 +17,7 @@ import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { ScrollArea } from '@/components/ui/scroll-area'
 import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group'
+import { extractFieldValues, stripHiddenValues } from '@/utils/metadata'
 
 import type { Image } from '@/types'
 
@@ -55,22 +57,10 @@ const ttlOptions = [
 ]
 
 const selectedImage = computed(() => props.images.find((i) => i.id === selectedImageId.value))
+const metadata = computed(() => selectedImage.value?.metadata ?? null)
 
-const imageMeta = computed(() => selectedImage.value?.metadata ?? [])
-
-const editableFields = computed(() => imageMeta.value.filter((m) => m.type === 'field'))
-const readOnlyItems = computed(() =>
-  imageMeta.value.filter((m) => m.type === 'setting' || m.type === 'info'),
-)
-
-function populateMetadataDefaults() {
-  const defaults: Record<string, string> = {}
-  for (const item of imageMeta.value) {
-    if (item.type === 'field' || item.type === 'setting') {
-      defaults[item.key] = item.value ?? ''
-    }
-  }
-  metadataValues.value = defaults
+function resetValues() {
+  metadataValues.value = { ...extractFieldValues(metadata.value) }
 }
 
 watch(
@@ -81,19 +71,18 @@ watch(
       displayName.value = ''
       ttlMinutes.value = '120'
       submitting.value = false
-      populateMetadataDefaults()
+      resetValues()
     }
   },
 )
 
-watch(selectedImageId, populateMetadataDefaults)
+watch(selectedImageId, resetValues)
 
 function handleSubmit() {
   if (!selectedImageId.value) return
   submitting.value = true
 
-  const metadata =
-    Object.keys(metadataValues.value).length > 0 ? { ...metadataValues.value } : undefined
+  const payload = stripHiddenValues(metadata.value, metadataValues.value)
 
   const trimmedName = displayName.value.trim()
   emit(
@@ -102,7 +91,7 @@ function handleSubmit() {
       imageId: selectedImageId.value,
       ttlMinutes: ttlMinutes.value === 'unlimited' ? 0 : Number(ttlMinutes.value),
       displayName: trimmedName || undefined,
-      metadata,
+      metadata: Object.keys(payload).length > 0 ? payload : undefined,
     },
     (success: boolean) => {
       submitting.value = false
@@ -116,14 +105,14 @@ function handleSubmit() {
 
 <template>
   <Dialog :open="open" @update:open="emit('update:open', $event)">
-    <DialogContent class="gap-0 p-0 sm:max-w-170">
+    <DialogContent class="flex h-[80vh] flex-col gap-0 overflow-hidden p-0 sm:max-w-[80vw]">
       <DialogHeader class="p-6 pb-4">
         <DialogTitle>Neue Sandbox</DialogTitle>
         <DialogDescription>Wähle eine Vorlage und konfiguriere die Laufzeit.</DialogDescription>
       </DialogHeader>
 
-      <div class="flex h-85 overflow-hidden border-t">
-        <div class="w-55 shrink-0 border-r">
+      <div class="flex min-h-0 flex-1 overflow-hidden border-t">
+        <div class="w-64 shrink-0 border-r">
           <ScrollArea class="h-full">
             <div class="p-2">
               <button
@@ -184,38 +173,12 @@ function handleSubmit() {
               </div>
             </div>
 
-            <div v-if="editableFields.length > 0" class="space-y-3">
-              <Label class="block">Konfiguration</Label>
-              <div v-for="item in editableFields" :key="item.key" class="grid gap-1.5">
-                <Label :for="'field-' + item.key" class="text-xs">
-                  {{ item.label }}
-                  <span v-if="item.required" class="text-destructive">*</span>
-                </Label>
-                <Input
-                  :id="'field-' + item.key"
-                  v-model="metadataValues[item.key]"
-                  :type="item.input === 'password' ? 'password' : 'text'"
-                  :placeholder="item.value"
-                  :disabled="submitting"
-                />
-              </div>
-            </div>
-
-            <div
-              v-if="readOnlyItems.length > 0"
-              class="bg-muted/50 space-y-1.5 rounded-md border px-3 py-2"
-            >
-              <div
-                v-for="item in readOnlyItems"
-                :key="item.key"
-                class="flex justify-between text-xs"
-              >
-                <span class="text-muted-foreground">{{ item.label }}</span>
-                <span class="font-mono text-[11px]">{{
-                  metadataValues[item.key] || item.value
-                }}</span>
-              </div>
-            </div>
+            <MetadataSection
+              v-model="metadataValues"
+              :metadata="metadata"
+              context="sandbox.create"
+              :disabled="submitting"
+            />
           </div>
 
           <div v-else class="text-muted-foreground flex h-full items-center justify-center text-sm">

--- a/web/src/components/modals/SnapshotDialog.vue
+++ b/web/src/components/modals/SnapshotDialog.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
-import { Loader2, Lock, Plus, Trash2, Upload } from 'lucide-vue-next'
+import { Loader2, Trash2, Upload } from 'lucide-vue-next'
 import { ref, watch } from 'vue'
 
 import { imagesApi } from '@/api'
-import IconPicker from '@/components/shared/IconPicker.vue'
+import MetadataEditor from '@/components/metadata/MetadataEditor.vue'
 import { Button } from '@/components/ui/button'
 import {
   Dialog,
@@ -18,14 +18,9 @@ import { Label } from '@/components/ui/label'
 import { Switch } from '@/components/ui/switch'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { Textarea } from '@/components/ui/textarea'
-import {
-  collectMetadata,
-  metadataItemToRow,
-  type MetadataRow,
-  newMetadataRow,
-} from '@/utils/metadata'
+import { isFieldItem } from '@/utils/metadata'
 
-import type { Image, MetadataItem, Sandbox } from '@/types'
+import type { Image, MetadataItem, MetadataSchema, Sandbox } from '@/types'
 
 const props = defineProps<{
   open: boolean
@@ -60,13 +55,22 @@ const thumbnailPreview = ref<string | undefined>()
 const busy = ref(false)
 const fileInputRef = ref<HTMLInputElement | null>(null)
 
-const fieldRows = ref<MetadataRow[]>([])
-const actionRows = ref<MetadataRow[]>([])
+const metadata = ref<MetadataItem[]>([])
+const registrySchema = ref<MetadataSchema | null>(null)
 
 function revokeBlobPreview() {
   if (thumbnailPreview.value?.startsWith('blob:')) {
     URL.revokeObjectURL(thumbnailPreview.value)
   }
+}
+
+function stripSecretValues(items: MetadataItem[]): MetadataItem[] {
+  return items.map((it) => {
+    if (isFieldItem(it) && it.field.input === 'password') {
+      return { ...it, field: { ...it.field, default: '' } }
+    }
+    return it
+  })
 }
 
 async function initFromSource() {
@@ -77,7 +81,6 @@ async function initFromSource() {
   if (fileInputRef.value) fileInputRef.value.value = ''
 
   const img = props.sourceImage
-  const sbx = props.sourceSandbox
 
   name.value = ''
   tag.value = ''
@@ -85,22 +88,8 @@ async function initFromSource() {
   description.value = img?.description ?? ''
   isPublic.value = img?.isPublic ?? false
 
-  let regKeys = new Set<string>()
-  if (img?.registryRef || img?.name) {
-    const regMeta = await imagesApi
-      .lookupRegistry(img.registryRef ?? img.name)
-      .catch(() => [] as MetadataItem[])
-    regKeys = new Set(regMeta.map((m) => m.key))
-  }
-
-  const allMeta: MetadataItem[] = Array.isArray(sbx?.metadata)
-    ? sbx.metadata
-    : (img?.metadata ?? [])
-
-  const toRow = (m: MetadataItem) => metadataItemToRow(m, regKeys.has(m.key))
-
-  fieldRows.value = allMeta.filter((m) => m.type === 'field' || m.type === 'setting').map(toRow)
-  actionRows.value = allMeta.filter((m) => m.type === 'action').map(toRow)
+  metadata.value = stripSecretValues(img?.metadata ?? [])
+  registrySchema.value = img ? await imagesApi.lookupRegistry(img.registryRef ?? img.name) : null
 }
 
 watch(
@@ -126,27 +115,9 @@ function handleRemoveThumbnail() {
   if (fileInputRef.value) fileInputRef.value.value = ''
 }
 
-function addField() {
-  fieldRows.value.push(newMetadataRow())
-}
-
-function removeField(index: number) {
-  fieldRows.value.splice(index, 1)
-}
-
-function addAction() {
-  actionRows.value.push(newMetadataRow())
-}
-
-function removeAction(index: number) {
-  actionRows.value.splice(index, 1)
-}
-
 function handleSubmit() {
   if (!name.value || !tag.value) return
   busy.value = true
-
-  const metadata = collectMetadata(fieldRows.value, actionRows.value)
 
   emit(
     'submit',
@@ -157,7 +128,7 @@ function handleSubmit() {
       description: description.value,
       isPublic: isPublic.value,
       thumbnailFile: thumbnailFile.value ?? undefined,
-      metadata,
+      metadata: metadata.value,
     },
     (success: boolean) => {
       busy.value = false
@@ -171,7 +142,7 @@ function handleSubmit() {
 
 <template>
   <Dialog :open="open" @update:open="emit('update:open', $event)">
-    <DialogContent class="max-h-[90vh] overflow-y-auto sm:max-w-[540px]">
+    <DialogContent class="max-h-[90vh] overflow-y-auto sm:max-w-[640px]">
       <DialogHeader>
         <DialogTitle>Snapshot erstellen</DialogTitle>
         <DialogDescription>
@@ -261,137 +232,8 @@ function handleSubmit() {
             </div>
           </TabsContent>
 
-          <TabsContent value="metadata" class="mt-4 grid min-h-[380px] content-start gap-4">
-            <div class="grid gap-2">
-              <Label>Felder</Label>
-              <div v-for="(row, index) in fieldRows" :key="index" class="space-y-1.5">
-                <div class="flex items-center gap-2">
-                  <div class="relative flex-1">
-                    <Input
-                      v-model="row.label"
-                      placeholder="Label"
-                      :disabled="busy || row.fromRegistry"
-                      :class="{ 'pr-7': row.fromRegistry }"
-                    />
-                    <Lock
-                      v-if="row.fromRegistry"
-                      class="text-muted-foreground absolute top-1/2 right-2 h-3.5 w-3.5 -translate-y-1/2"
-                    />
-                  </div>
-                  <Input v-model="row.value" placeholder="Wert" class="flex-1" :disabled="busy" />
-                  <Button
-                    v-if="!row.fromRegistry"
-                    type="button"
-                    variant="ghost"
-                    size="icon"
-                    :disabled="busy"
-                    @click="removeField(index)"
-                  >
-                    <Trash2 class="h-4 w-4" />
-                  </Button>
-                  <div v-else class="w-9" />
-                </div>
-                <div v-if="!row.fromRegistry" class="flex gap-1.5 pl-0.5">
-                  <IconPicker v-model="row.icon" :disabled="busy" />
-                  <select
-                    v-model="row.show"
-                    class="border-input bg-background h-7 rounded-md border px-1.5 text-[11px]"
-                    :disabled="busy"
-                  >
-                    <option value="sandbox">Sandbox</option>
-                    <option value="template">Template</option>
-                    <option value="both">Beide</option>
-                  </select>
-                  <select
-                    v-model="row.condition"
-                    class="border-input bg-background h-7 rounded-md border px-1.5 text-[11px]"
-                    :disabled="busy"
-                  >
-                    <option value="always">Immer</option>
-                    <option value="ready">Wenn bereit</option>
-                  </select>
-                </div>
-              </div>
-              <Button type="button" variant="outline" size="sm" :disabled="busy" @click="addField">
-                <Plus class="mr-1 h-4 w-4" />
-                Feld hinzufügen
-              </Button>
-            </div>
-
-            <div class="grid gap-2">
-              <Label>Aktionen</Label>
-              <div v-for="(row, index) in actionRows" :key="index" class="space-y-1.5">
-                <div class="flex items-center gap-2">
-                  <div class="relative flex-1">
-                    <Input
-                      v-model="row.label"
-                      placeholder="Label"
-                      :disabled="busy || row.fromRegistry"
-                      :class="{ 'pr-7': row.fromRegistry }"
-                    />
-                    <Lock
-                      v-if="row.fromRegistry"
-                      class="text-muted-foreground absolute top-1/2 right-2 h-3.5 w-3.5 -translate-y-1/2"
-                    />
-                  </div>
-                  <div class="relative flex-1">
-                    <Input
-                      v-model="row.value"
-                      placeholder="https://..."
-                      :disabled="busy || row.fromRegistry"
-                      :class="{ 'pr-7': row.fromRegistry }"
-                    />
-                    <Lock
-                      v-if="row.fromRegistry"
-                      class="text-muted-foreground absolute top-1/2 right-2 h-3.5 w-3.5 -translate-y-1/2"
-                    />
-                  </div>
-                  <Button
-                    v-if="!row.fromRegistry"
-                    type="button"
-                    variant="ghost"
-                    size="icon"
-                    :disabled="busy"
-                    @click="removeAction(index)"
-                  >
-                    <Trash2 class="h-4 w-4" />
-                  </Button>
-                  <div v-else class="w-9" />
-                </div>
-                <div v-if="!row.fromRegistry" class="flex gap-1.5 pl-0.5">
-                  <IconPicker v-model="row.icon" :disabled="busy" />
-                  <select
-                    v-model="row.show"
-                    class="border-input bg-background h-7 rounded-md border px-1.5 text-[11px]"
-                    :disabled="busy"
-                  >
-                    <option value="sandbox">Sandbox</option>
-                    <option value="template">Template</option>
-                    <option value="both">Beide</option>
-                  </select>
-                  <select
-                    v-model="row.condition"
-                    class="border-input bg-background h-7 rounded-md border px-1.5 text-[11px]"
-                    :disabled="busy"
-                  >
-                    <option value="always">Immer</option>
-                    <option value="ready">Wenn bereit</option>
-                  </select>
-                  <select
-                    v-model="row.size"
-                    class="border-input bg-background h-7 rounded-md border px-1.5 text-[11px]"
-                    :disabled="busy"
-                  >
-                    <option value="default">Normal</option>
-                    <option value="icon">Nur Icon</option>
-                  </select>
-                </div>
-              </div>
-              <Button type="button" variant="outline" size="sm" :disabled="busy" @click="addAction">
-                <Plus class="mr-1 h-4 w-4" />
-                Aktion hinzufügen
-              </Button>
-            </div>
+          <TabsContent value="metadata" class="mt-4 min-h-[380px]">
+            <MetadataEditor v-model="metadata" :registry-schema="registrySchema" :disabled="busy" />
           </TabsContent>
         </Tabs>
 

--- a/web/src/components/modals/sandbox-detail/ConfigTab.vue
+++ b/web/src/components/modals/sandbox-detail/ConfigTab.vue
@@ -1,61 +1,28 @@
 <script setup lang="ts">
-import { Eye, EyeOff } from 'lucide-vue-next'
-import { ref } from 'vue'
+import { computed } from 'vue'
 
-import CopyButton from '@/components/shared/CopyButton.vue'
-import { Button } from '@/components/ui/button'
+import MetadataSection from '@/components/metadata/MetadataSection.vue'
+import { extractFieldValues } from '@/utils/metadata'
 
-import type { MetadataItem } from '@/types'
+import type { Sandbox } from '@/types'
 
-defineProps<{
-  items: MetadataItem[]
+const props = defineProps<{
+  sandbox: Sandbox
 }>()
 
-const revealedKeys = ref(new Set<string>())
+const values = computed(() => extractFieldValues(props.sandbox.metadata))
+const metadata = computed(() => props.sandbox.metadata ?? [])
 
-function isSecret(item: MetadataItem): boolean {
-  return item.input === 'password' || item.key.toLowerCase().includes('password')
-}
-
-function toggleReveal(key: string) {
-  if (revealedKeys.value.has(key)) {
-    revealedKeys.value.delete(key)
-  } else {
-    revealedKeys.value.add(key)
-  }
-}
-
-function displayValue(item: MetadataItem): string {
-  const val = item.value || '—'
-  if (!isSecret(item) || revealedKeys.value.has(item.key)) return val
-  return '•'.repeat(Math.min(val.length, 12))
-}
-
-defineExpose({ resetRevealed: () => revealedKeys.value.clear() })
+defineExpose({ resetRevealed: () => {} })
 </script>
 
 <template>
-  <table class="w-full text-sm">
-    <tbody class="divide-y">
-      <tr v-for="item in items" :key="item.key">
-        <td class="text-muted-foreground w-1/3 py-2 pr-4 text-xs">{{ item.label }}</td>
-        <td class="py-2">
-          <div class="flex items-center gap-1">
-            <span>{{ displayValue(item) }}</span>
-            <Button
-              v-if="isSecret(item) && item.value"
-              variant="ghost"
-              size="icon-sm"
-              class="h-6 w-6"
-              @click.stop="toggleReveal(item.key)"
-            >
-              <EyeOff v-if="revealedKeys.has(item.key)" class="h-3 w-3" />
-              <Eye v-else class="h-3 w-3" />
-            </Button>
-            <CopyButton v-if="item.value" :value="item.value" />
-          </div>
-        </td>
-      </tr>
-    </tbody>
-  </table>
+  <MetadataSection
+    :metadata="metadata"
+    context="sandbox.details"
+    :model-value="values"
+    view="form"
+    disabled
+    :actions-disabled="sandbox.status !== 'running'"
+  />
 </template>

--- a/web/src/components/modals/sandbox-detail/SandboxDetailDialog.vue
+++ b/web/src/components/modals/sandbox-detail/SandboxDetailDialog.vue
@@ -12,6 +12,7 @@ import {
 } from '@/components/ui/dialog'
 import { Separator } from '@/components/ui/separator'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
+import { itemsForContext } from '@/utils/metadata'
 
 import AccessTab from './AccessTab.vue'
 import ConfigTab from './ConfigTab.vue'
@@ -58,12 +59,10 @@ const isOffline = computed(
   () => props.sandbox?.status === 'running' && props.health && !props.health.ready,
 )
 
-const visibleMetadata = computed(() => {
-  if (!Array.isArray(props.sandbox?.metadata)) return []
-  return props.sandbox.metadata.filter((m) => m.show !== 'template' && m.type !== 'action')
+const hasConfigTab = computed(() => {
+  const items = itemsForContext(props.sandbox?.metadata, 'sandbox.details')
+  return items.length > 0
 })
-
-const hasConfigTab = computed(() => visibleMetadata.value.length > 0)
 const hasAccessTab = computed(() => isActive.value && !!props.sandbox?.ssh)
 const hasFilesTab = computed(() => isActive.value)
 const hasTerminalTab = computed(() => isActive.value && !!props.sandbox?.owner)
@@ -111,7 +110,7 @@ const hasTerminalTab = computed(() => isActive.value && !!props.sandbox?.owner)
           value="config"
           class="flex-1 overflow-y-auto px-6 pt-4 pb-6"
         >
-          <ConfigTab ref="configTabRef" :items="visibleMetadata" />
+          <ConfigTab v-if="sandbox" ref="configTabRef" :sandbox="sandbox" />
         </TabsContent>
 
         <TabsContent

--- a/web/src/composables/useImages.ts
+++ b/web/src/composables/useImages.ts
@@ -183,22 +183,20 @@ export function useImages(mode: FetchMode = 'public') {
 
   async function updateImage(id: string, req: UpdateImageRequest): Promise<Image> {
     const updated = await imagesApi.update(id, req)
-    const idx = images.value.findIndex((i) => i.id === id)
-    if (idx !== -1) images.value[idx] = updated
+    store.upsertImage(updated)
     return updated
   }
 
   async function uploadThumbnail(id: string, file: File): Promise<Image> {
     const updated = await imagesApi.uploadThumbnail(id, file)
-    const idx = images.value.findIndex((i) => i.id === id)
-    if (idx !== -1) images.value[idx] = updated
+    store.upsertImage(updated)
     return updated
   }
 
   async function deleteThumbnail(id: string): Promise<void> {
     await imagesApi.deleteThumbnail(id)
-    const idx = images.value.findIndex((i) => i.id === id)
-    if (idx !== -1) images.value[idx] = { ...images.value[idx], thumbnailUrl: undefined }
+    const current = images.value.find((i) => i.id === id)
+    if (current) store.upsertImage({ ...current, thumbnailUrl: undefined })
   }
 
   async function deleteImage(id: string) {

--- a/web/src/stores/images.store.ts
+++ b/web/src/stores/images.store.ts
@@ -23,6 +23,12 @@ export const useImagesStore = defineStore('images', () => {
     error.value = null
   }
 
+  function upsertImage(image: Image) {
+    const idx = images.value.findIndex((i) => i.id === image.id)
+    if (idx === -1) images.value.push(image)
+    else images.value[idx] = image
+  }
+
   return {
     images,
     pendingImages,
@@ -32,5 +38,6 @@ export const useImagesStore = defineStore('images', () => {
     fetchMode,
     publicImages,
     $reset,
+    upsertImage,
   }
 })

--- a/web/src/types/api.types.ts
+++ b/web/src/types/api.types.ts
@@ -19,21 +19,105 @@ export interface UserSummary {
 
 export type ImageStatus = 'pulling' | 'committing' | 'ready' | 'failed'
 
-export type MetadataType = 'field' | 'setting' | 'info' | 'action'
+export type MetadataContext =
+  | 'image.create'
+  | 'image.edit'
+  | 'image.card'
+  | 'sandbox.create'
+  | 'sandbox.card'
+  | 'sandbox.details'
 
-export interface MetadataItem {
+export type FieldInput =
+  | 'text'
+  | 'password'
+  | 'number'
+  | 'email'
+  | 'url'
+  | 'select'
+  | 'multiselect'
+  | 'toggle'
+  | 'textarea'
+
+export type DisplayFormat = 'text' | 'code' | 'badge' | 'link' | 'password'
+
+export type ActionVariant = 'default' | 'outline' | 'destructive'
+export type ActionSize = 'default' | 'icon'
+export type ActionTarget = '_blank' | '_self'
+
+export interface SelectOption {
+  value: string
+  label: string
+}
+
+export interface FieldDependency {
+  field: string
+  value: string
+}
+
+export interface VisibilityRule {
+  contexts?: MetadataContext[]
+  condition?: string
+  dependsOn?: FieldDependency
+}
+
+export interface FieldSpec {
+  input: FieldInput
+  default?: string
+  placeholder?: string
+  helpText?: string
+  required?: boolean
+  readOnly?: boolean
+  options?: SelectOption[]
+}
+
+export interface ActionSpec {
+  url: string
+  variant?: ActionVariant
+  size?: ActionSize
+  target?: ActionTarget
+  confirm?: string
+}
+
+export interface DisplaySpec {
+  value: string
+  format?: DisplayFormat
+  copyable?: boolean
+}
+
+interface BaseMetadataItem {
   key: string
   label: string
-  type: MetadataType
-  value?: string
-  input?: string
-  required?: boolean
-  options?: string[]
-  variant?: string
-  show?: 'sandbox' | 'template' | 'both'
-  condition?: 'ready' | 'always'
   icon?: string
-  size?: 'default' | 'icon'
+  group?: string
+  visibility?: VisibilityRule
+}
+
+export interface FieldItem extends BaseMetadataItem {
+  type: 'field'
+  field: FieldSpec
+}
+
+export interface ActionItem extends BaseMetadataItem {
+  type: 'action'
+  action: ActionSpec
+}
+
+export interface DisplayItem extends BaseMetadataItem {
+  type: 'display'
+  display: DisplaySpec
+}
+
+export type MetadataItem = FieldItem | ActionItem | DisplayItem
+
+export interface MetadataGroup {
+  key: string
+  label: string
+  description?: string
+}
+
+export interface MetadataSchema {
+  groups?: MetadataGroup[]
+  items: MetadataItem[]
 }
 
 export interface Image extends BaseModel {
@@ -46,7 +130,7 @@ export interface Image extends BaseModel {
   isPublic: boolean
   status: ImageStatus
   error?: string
-  metadata?: MetadataItem[]
+  metadata: MetadataItem[]
   registryRef?: string
   owner?: UserSummary | null
 }
@@ -92,7 +176,7 @@ export interface Sandbox extends BaseModel {
   port?: number
   ssh?: SSHConnection
   clientIp: string
-  metadata?: MetadataItem[]
+  metadata: MetadataItem[]
   expiresAt?: string
   lastSeenAt?: string
 }

--- a/web/src/utils/metadata.ts
+++ b/web/src/utils/metadata.ts
@@ -1,70 +1,110 @@
-import type { MetadataItem } from '@/types'
+import type { DisplayItem, FieldItem, MetadataContext, MetadataGroup, MetadataItem } from '@/types'
 
-export interface MetadataRow {
-  key: string
-  label: string
-  value: string
-  fromRegistry: boolean
-  icon: string
-  show: string
-  condition: string
-  size: string
-}
-
-export function newMetadataRow(): MetadataRow {
-  return {
-    key: '',
-    label: '',
-    value: '',
-    fromRegistry: false,
-    icon: '',
-    show: 'sandbox',
-    condition: 'always',
-    size: 'default',
-  }
-}
-
-export function rowToMetadataItem(row: MetadataRow, type: MetadataItem['type']): MetadataItem {
-  return {
-    key: row.key || row.label.toLowerCase().replace(/\s+/g, '_'),
-    label: row.label,
-    type,
-    value: row.value,
-    icon: row.icon || undefined,
-    show: (row.show as MetadataItem['show']) || undefined,
-    condition: (row.condition as MetadataItem['condition']) || undefined,
-    size: (row.size as MetadataItem['size']) || undefined,
-  }
-}
-
-export function metadataItemToRow(m: MetadataItem, fromRegistry: boolean): MetadataRow {
-  return {
-    key: m.key,
-    label: m.label,
-    value: m.value ?? '',
-    fromRegistry,
-    icon: m.icon ?? '',
-    show: m.show ?? 'sandbox',
-    condition: m.condition ?? 'always',
-    size: m.size ?? 'default',
-  }
-}
-
-export function collectMetadata(
-  fieldRows: MetadataRow[],
-  actionRows: MetadataRow[],
+export function itemsForContext(
+  metadata: MetadataItem[] | null | undefined,
+  ctx: MetadataContext,
 ): MetadataItem[] {
-  const metadata: MetadataItem[] = []
+  if (!metadata) return []
+  return metadata.filter((item) => {
+    const contexts = item.visibility?.contexts
+    if (!contexts || contexts.length === 0) return true
+    return contexts.includes(ctx)
+  })
+}
 
-  for (const row of fieldRows) {
-    if (!row.label) continue
-    metadata.push(rowToMetadataItem(row, 'field'))
+export function evaluateDependsOn(item: MetadataItem, values: Record<string, string>): boolean {
+  const dep = item.visibility?.dependsOn
+  if (!dep) return true
+  return values[dep.field] === dep.value
+}
+
+export function evaluateCondition(
+  condition: string | undefined,
+  runtime: { ready?: boolean },
+): boolean {
+  if (!condition) return true
+  if (condition === 'ready') return runtime.ready === true
+  return true
+}
+
+export function groupItems(
+  items: MetadataItem[],
+  groups: MetadataGroup[] | undefined,
+): Array<{ group: MetadataGroup | null; items: MetadataItem[] }> {
+  const orderedKeys = (groups ?? []).map((g) => g.key)
+  const bucketByKey = new Map<string, MetadataItem[]>()
+  for (const key of orderedKeys) bucketByKey.set(key, [])
+  const defaults: MetadataItem[] = []
+
+  for (const item of items) {
+    if (item.group && bucketByKey.has(item.group)) {
+      bucketByKey.get(item.group)!.push(item)
+    } else {
+      defaults.push(item)
+    }
   }
 
-  for (const row of actionRows) {
-    if (row.fromRegistry || !row.label) continue
-    metadata.push(rowToMetadataItem(row, 'action'))
+  const result: Array<{ group: MetadataGroup | null; items: MetadataItem[] }> = []
+  for (const g of groups ?? []) {
+    const bucket = bucketByKey.get(g.key) ?? []
+    if (bucket.length > 0) result.push({ group: g, items: bucket })
   }
+  if (defaults.length > 0) result.push({ group: null, items: defaults })
+  return result
+}
 
-  return metadata
+export const isFieldItem = (i: MetadataItem): i is FieldItem => i.type === 'field'
+
+export function extractFieldValues(
+  metadata: MetadataItem[] | null | undefined,
+): Record<string, string> {
+  const out: Record<string, string> = {}
+  if (!metadata) return out
+  for (const item of metadata) {
+    if (!isFieldItem(item)) continue
+    if (item.field.default !== undefined) out[item.key] = item.field.default
+  }
+  return out
+}
+
+export function stripHiddenValues(
+  metadata: MetadataItem[] | null | undefined,
+  values: Record<string, string>,
+): Record<string, string> {
+  if (!metadata) return { ...values }
+  const out: Record<string, string> = {}
+  for (const item of metadata) {
+    if (!isFieldItem(item)) continue
+    if (!evaluateDependsOn(item, values)) continue
+    if (item.key in values) out[item.key] = values[item.key]
+  }
+  return out
+}
+
+export function isSecretItem(item: MetadataItem): boolean {
+  if (item.type === 'field') return item.field.input === 'password'
+  if (item.type === 'display') return item.display.format === 'password'
+  return false
+}
+
+export function fieldAsDisplay(item: FieldItem, copyable = true): DisplayItem {
+  return {
+    key: item.key,
+    label: item.label,
+    icon: item.icon,
+    group: item.group,
+    visibility: item.visibility,
+    type: 'display',
+    display: {
+      value: item.field.default ?? '',
+      format: item.field.input === 'password' ? 'password' : 'text',
+      copyable,
+    },
+  }
+}
+
+export function maskSecret(value: string): string {
+  const len = value?.length ?? 0
+  if (len === 0) return '••••••••'
+  return '•'.repeat(Math.min(Math.max(len, 4), 12))
 }

--- a/web/src/views/explore/ExploreView.vue
+++ b/web/src/views/explore/ExploreView.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ExternalLink, Play, Trash2 } from 'lucide-vue-next'
+import { Play, Trash2 } from 'lucide-vue-next'
 import { computed, ref } from 'vue'
 import { toast } from 'vue-sonner'
 
@@ -12,11 +12,10 @@ import { useImages } from '@/composables/useImages'
 import { useSandboxes } from '@/composables/useSandboxes'
 import { getApiErrorMessage } from '@/utils/error'
 import { resolveAssetUrl } from '@/utils/formatters'
-import { resolveIcon } from '@/utils/icons'
+import { extractFieldValues } from '@/utils/metadata'
 
 import type { CardAction } from '@/components/explore/ActionButton.vue'
-import type { MetadataGroup } from '@/components/explore/SandboxCard.vue'
-import type { Image, MetadataItem, Sandbox } from '@/types'
+import type { Image, Sandbox } from '@/types'
 
 const { images, loading: imagesLoading } = useImages()
 const {
@@ -32,10 +31,6 @@ const shredderRefs = ref<Record<string, InstanceType<typeof ShredderAnimation>>>
 
 const hasActiveSandboxes = computed(() => activeSandboxes.value.length > 0)
 
-function isSandboxReachable(sandbox: Sandbox): boolean {
-  return sandbox.status === 'running'
-}
-
 function getImageForSandbox(sandbox: Sandbox): Image | undefined {
   return images.value.find((i) => i.id === sandbox.imageId)
 }
@@ -50,163 +45,33 @@ function getImageThumbnail(sandbox: Sandbox): string | undefined {
   return resolveAssetUrl(getImageForSandbox(sandbox)?.thumbnailUrl)
 }
 
-function getSandboxMetadata(sandbox: Sandbox): MetadataItem[] {
-  if (!sandbox.metadata || !Array.isArray(sandbox.metadata)) return []
-  return sandbox.metadata
+function sandboxExtraActions(sandbox: Sandbox): CardAction[] {
+  if (sandbox.status !== 'running' && sandbox.status !== 'starting') return []
+  return [
+    {
+      label: 'Stoppen',
+      variant: 'destructive',
+      icon: Trash2,
+      size: 'icon',
+      tooltip: 'Stoppen',
+      loading: busyIds.value.has(sandbox.id),
+      disabled: busyIds.value.has(sandbox.id),
+      onClick: () => handleStopSandbox(sandbox),
+    },
+  ]
 }
 
-function resolveActionUrl(template: string, sandbox: Sandbox): string {
-  return template
-    .replace(/\{\{\.URL}}/g, sandbox.url)
-    .replace(/\{\{\.Hostname}}/g, sandbox.url.replace(/^https?:\/\//, ''))
-    .replace(/\{\{\.SandboxID}}/g, sandbox.id)
-}
-
-function showOnSandbox(item: MetadataItem): boolean {
-  return !item.show || item.show === 'sandbox' || item.show === 'both'
-}
-
-function showOnTemplate(item: MetadataItem): boolean {
-  return item.show === 'template' || item.show === 'both'
-}
-
-function isDisabledByCondition(item: MetadataItem, sandbox: Sandbox): boolean {
-  if (item.condition === 'ready') return !isSandboxReachable(sandbox)
-  return false
-}
-
-function metadataToAction(item: MetadataItem, sandbox: Sandbox): CardAction {
-  return {
-    label: item.label,
-    href: resolveActionUrl(item.value ?? '', sandbox),
-    variant: (item.variant as CardAction['variant']) ?? 'outline',
-    icon: resolveIcon(item.icon) ?? ExternalLink,
-    disabled: isDisabledByCondition(item, sandbox),
-    size: (item.size as CardAction['size']) ?? 'default',
-    tooltip: item.size === 'icon' ? item.label : undefined,
-  }
-}
-
-const sandboxActionsMap = computed(() => {
-  const map: Record<string, CardAction[]> = {}
-  for (const sandbox of activeSandboxes.value) {
-    const meta = getSandboxMetadata(sandbox)
-    const actionItems = meta.filter((m) => m.type === 'action' && showOnSandbox(m))
-    const actions: CardAction[] = []
-
-    if (actionItems.length > 0) {
-      for (const item of actionItems) {
-        actions.push(metadataToAction(item, sandbox))
-      }
-    } else {
-      actions.push({
-        label: 'Öffnen',
-        href: sandbox.url,
-        variant: 'default',
-        icon: ExternalLink,
-        disabled: !isSandboxReachable(sandbox),
-      })
-    }
-
-    if (sandbox.status === 'running' || sandbox.status === 'starting') {
-      actions.push({
-        label: 'Stoppen',
-        variant: 'destructive',
-        icon: Trash2,
-        size: 'icon',
-        tooltip: 'Stoppen',
-        loading: busyIds.value.has(sandbox.id),
-        disabled: busyIds.value.has(sandbox.id),
-        onClick: () => handleStopSandbox(sandbox),
-      })
-    }
-    map[sandbox.id] = actions
-  }
-  return map
-})
-
-function metadataToField(item: MetadataItem, sandbox?: Sandbox) {
-  return {
-    label: item.label,
-    value: item.value || '',
-    secret: item.input === 'password',
-    icon: item.icon,
-    loading: sandbox ? isDisabledByCondition(item, sandbox) : false,
-  }
-}
-
-const sandboxMetadataMap = computed(() => {
-  const map: Record<string, MetadataGroup[]> = {}
-  for (const sandbox of activeSandboxes.value) {
-    const meta = getSandboxMetadata(sandbox)
-    const groups: MetadataGroup[] = []
-
-    const configItems = meta.filter(
-      (m) => (m.type === 'field' || m.type === 'setting') && showOnSandbox(m),
-    )
-    if (configItems.length > 0) {
-      groups.push({
-        title: 'Konfiguration',
-        fields: configItems.map((m) => metadataToField(m, sandbox)),
-      })
-    }
-
-    const infoItems = meta.filter((m) => m.type === 'info' && showOnSandbox(m))
-    if (infoItems.length > 0) {
-      groups.push({ title: 'Details', fields: infoItems.map((m) => metadataToField(m, sandbox)) })
-    }
-
-    if (groups.length > 0) map[sandbox.id] = groups
-  }
-  return map
-})
-
-function getPresetMetadata(image: Image): MetadataGroup[] {
-  const meta = image.metadata ?? []
-  const groups: MetadataGroup[] = []
-
-  const configItems = meta.filter(
-    (m) => (m.type === 'field' || m.type === 'setting') && showOnTemplate(m),
-  )
-  if (configItems.length > 0) {
-    groups.push({ title: 'Konfiguration', fields: configItems.map((m) => metadataToField(m)) })
-  }
-
-  const infoItems = meta.filter((m) => m.type === 'info' && showOnTemplate(m))
-  if (infoItems.length > 0) {
-    groups.push({ title: 'Details', fields: infoItems.map((m) => metadataToField(m)) })
-  }
-
-  return groups
-}
-
-function getPresetActions(image: Image): CardAction[] {
-  const actions: CardAction[] = []
-
-  const templateActions = (image.metadata ?? []).filter(
-    (m) => m.type === 'action' && showOnTemplate(m),
-  )
-  for (const item of templateActions) {
-    actions.push({
-      label: item.label,
-      href: item.value,
-      variant: (item.variant as CardAction['variant']) ?? 'outline',
-      icon: resolveIcon(item.icon) ?? ExternalLink,
-      size: (item.size as CardAction['size']) ?? 'default',
-      tooltip: item.size === 'icon' ? item.label : undefined,
-    })
-  }
-
-  actions.push({
-    label: 'Demo starten',
-    variant: 'default',
-    icon: Play,
-    loading: busyIds.value.has(image.id),
-    disabled: busyIds.value.has(image.id),
-    onClick: () => handleDemo(image.id),
-  })
-
-  return actions
+function presetExtraActions(image: Image): CardAction[] {
+  return [
+    {
+      label: 'Demo starten',
+      variant: 'default',
+      icon: Play,
+      loading: busyIds.value.has(image.id),
+      disabled: busyIds.value.has(image.id),
+      onClick: () => handleDemo(image.id),
+    },
+  ]
 }
 
 async function handleStopSandbox(sandbox: Sandbox) {
@@ -226,15 +91,9 @@ async function handleStopSandbox(sandbox: Sandbox) {
   }
 }
 
-function getMetadataDefaults(imageId: string): Record<string, string> | undefined {
+function defaultsForImage(imageId: string): Record<string, string> | undefined {
   const image = images.value.find((i) => i.id === imageId)
-  const meta = image?.metadata ?? []
-  const defaults: Record<string, string> = {}
-  for (const item of meta) {
-    if ((item.type === 'field' || item.type === 'setting') && item.value) {
-      defaults[item.key] = item.value
-    }
-  }
+  const defaults = extractFieldValues(image?.metadata)
   return Object.keys(defaults).length > 0 ? defaults : undefined
 }
 
@@ -242,7 +101,7 @@ async function handleDemo(imageId: string) {
   if (busyIds.value.has(imageId)) return
   busyIds.value.add(imageId)
   try {
-    const metadata = getMetadataDefaults(imageId)
+    const metadata = defaultsForImage(imageId)
     await createSandbox({ imageId, metadata })
     toast.success('Demo wird gestartet')
     refreshSandboxes()
@@ -267,7 +126,7 @@ async function handleDemo(imageId: string) {
         <CardGridSkeleton v-if="sandboxesLoading" :count="2" variant="sandbox" />
         <div
           v-else-if="hasActiveSandboxes"
-          class="grid auto-rows-[460px] grid-cols-[repeat(auto-fill,minmax(320px,1fr))] gap-4"
+          class="grid auto-rows-fr grid-cols-[repeat(auto-fill,minmax(320px,1fr))] gap-4"
         >
           <ShredderAnimation
             v-for="sandbox in activeSandboxes"
@@ -282,9 +141,9 @@ async function handleDemo(imageId: string) {
               :sandbox="sandbox"
               :title="getImageTitle(sandbox)"
               :thumbnail-url="getImageThumbnail(sandbox)"
-              :actions="sandboxActionsMap[sandbox.id]"
-              :metadata="sandboxMetadataMap[sandbox.id]"
+              :extra-actions="sandboxExtraActions(sandbox)"
               :state-reason="sandbox.stateReason"
+              context="sandbox.card"
             />
           </ShredderAnimation>
         </div>
@@ -293,12 +152,7 @@ async function handleDemo(imageId: string) {
       <section>
         <h3 class="text-muted-foreground mb-3 text-sm font-medium">Vorlagen</h3>
         <CardGridSkeleton v-if="imagesLoading" :count="6" />
-        <PresetGrid
-          v-else
-          :images="images"
-          :get-actions="getPresetActions"
-          :get-metadata="getPresetMetadata"
-        />
+        <PresetGrid v-else :images="images" :get-extra-actions="presetExtraActions" />
       </section>
     </div>
   </div>


### PR DESCRIPTION
This pull request refactors how metadata is handled and exposed for images and sandboxes, moving from raw JSON fields to structured, enriched metadata objects. It also cleans up and improves the registry lookup and response logic. The main changes are grouped below:

**Metadata Handling and API Response Changes:**

* The `Metadata` field in both `ImageResponse` and `SandboxResponse` DTOs is now a structured `[]registry.MetadataItem` instead of raw JSON, providing clients with a more meaningful and validated metadata representation. (`api/internal/http/dto/image.go` [[1]](diffhunk://#diff-1ad1b632cb47e9d56d5f546ded00e9a282d27a84d19f86c899174161dfd35da9L46-R45) `api/internal/http/dto/sandbox.go` [[2]](diffhunk://#diff-6fa9d85d60a8dbb5b3cfc57bda80d5f077d08ab53eb570386f6ba2fa9112279bL46-R46)
* The internal `Metadata` fields in the `Image` and `Sandbox` models are now hidden from API output (`json:"-" swaggerignore:"true"`), ensuring only enriched metadata is exposed via the API. (`api/internal/models/image.go` [[1]](diffhunk://#diff-95a0ea9594e40f0dd8621b8b488f36520147bd59e06cdb4407575c16929e3283L25-R25) `api/internal/models/sandbox.go` [[2]](diffhunk://#diff-d34be0f56c27749e175ab816fa9794b40ff964142f0d2e78ed63512a37f44202L53-R53)
* All handler functions that return image or sandbox responses now use new helper functions (`imageResponseFor`, `sandboxResponseFor`) to ensure metadata enrichment is consistently applied. (`api/internal/http/handlers/image_handler.go` [[1]](diffhunk://#diff-8b6aec5aed7dce2bffa7d290a919f703ee1134e4973a8553712e61a6ee3cba91L94-R95) [[2]](diffhunk://#diff-8b6aec5aed7dce2bffa7d290a919f703ee1134e4973a8553712e61a6ee3cba91L170-R170) [[3]](diffhunk://#diff-8b6aec5aed7dce2bffa7d290a919f703ee1134e4973a8553712e61a6ee3cba91L109-R118) `api/internal/http/handlers/sandbox_handler.go` [[4]](diffhunk://#diff-c68ba4e9ff229cb7f29f2e23b419cd961fd8204caa11c2ca9f80149f49a490d6L86-R88) [[5]](diffhunk://#diff-c68ba4e9ff229cb7f29f2e23b419cd961fd8204caa11c2ca9f80149f49a490d6L133-R134) [[6]](diffhunk://#diff-c68ba4e9ff229cb7f29f2e23b419cd961fd8204caa11c2ca9f80149f49a490d6L163-R163) [[7]](diffhunk://#diff-c68ba4e9ff229cb7f29f2e23b419cd961fd8204caa11c2ca9f80149f49a490d6L374-R392)

**Registry Lookup and Metadata Schema:**

* The registry lookup endpoint now returns a `MetadataSchema` object (with an `Items` array) instead of a raw list, and uses a new `SchemaFor` method for lookups, providing a more robust and extensible API. (`api/internal/http/handlers/image_handler.go` [[1]](diffhunk://#diff-8b6aec5aed7dce2bffa7d290a919f703ee1134e4973a8553712e61a6ee3cba91L268-R314) [[2]](diffhunk://#diff-8b6aec5aed7dce2bffa7d290a919f703ee1134e4973a8553712e61a6ee3cba91L24-R24)
* The registry validation logic is now encapsulated in a renamed function `validateRegistry`, improving code clarity. (`api/internal/registry/loader.go` [api/internal/registry/loader.goL22-L90](diffhunk://#diff-6d688445f89d3b72447aaed6eee3b6655446f215ebea08000d0918a67d815b38L22-L90))

**Handler and Service Integration:**

* The `SandboxHandler` now has access to the `ImageService` for consistent metadata enrichment and response formatting. (`api/internal/http/handlers/sandbox_handler.go` [[1]](diffhunk://#diff-c68ba4e9ff229cb7f29f2e23b419cd961fd8204caa11c2ca9f80149f49a490d6R26) `api/internal/http/routes.go` [[2]](diffhunk://#diff-acabff3af9cc8717a97f9e1a8adba5d1f93e8f1dd0d1e107fe23e240f1d05207L121-R121)
* When creating or updating images and sandboxes, metadata is passed as structured objects rather than marshaled JSON, simplifying the code and reducing error-prone conversions. (`api/internal/http/handlers/image_handler.go` [[1]](diffhunk://#diff-8b6aec5aed7dce2bffa7d290a919f703ee1134e4973a8553712e61a6ee3cba91L75-R83) [[2]](diffhunk://#diff-8b6aec5aed7dce2bffa7d290a919f703ee1134e4973a8553712e61a6ee3cba91L109-R118) `api/internal/http/handlers/sandbox_handler.go` [[3]](diffhunk://#diff-c68ba4e9ff229cb7f29f2e23b419cd961fd8204caa11c2ca9f80149f49a490d6L227) [[4]](diffhunk://#diff-c68ba4e9ff229cb7f29f2e23b419cd961fd8204caa11c2ca9f80149f49a490d6L237-R243)

**DTO and Handler Cleanups:**

* Removed unnecessary imports and JSON marshaling logic, streamlining the handler implementations. (`api/internal/http/handlers/sandbox_handler.go` [[1]](diffhunk://#diff-c68ba4e9ff229cb7f29f2e23b419cd961fd8204caa11c2ca9f80149f49a490d6L5) [[2]](diffhunk://#diff-c68ba4e9ff229cb7f29f2e23b419cd961fd8204caa11c2ca9f80149f49a490d6L227)

These changes together make the API responses more structured, reliable, and easier to use for clients, while also simplifying and clarifying the backend codebase.